### PR TITLE
Cannot read from progmem array directly.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -649,7 +649,7 @@ void RF24::openReadingPipe(uint8_t child, uint64_t address)
     // Note it would be more efficient to set all of the bits for all open
     // pipes at once.  However, I thought it would make the calling code
     // more simple to do it this way.
-    write_register(EN_RXADDR,read_register(EN_RXADDR) | _BV(child_pipe_enable[child]));
+    write_register(EN_RXADDR,read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[child])));
   }
 }
 


### PR DESCRIPTION
After playing with RF24Network meshping example, I noticed that I could not use addresses which involves pipes 2-5. I dug into the NRF24L01+ datasheet and the RF24 library and found out that EN_RXADDR was always set to 0x03 (pipe 0 and 1, default) after initializing, no matter which pipe you tried to open for reading.

Then I looked at openReadingPipe() in RF24.cpp and noticed that `_BV(child_pipe_enable[child])` always returned 1, no matter the value of `child`. I fixed the problem and now the RF24Network meshping example works for me (which fixes https://github.com/maniacbug/RF24Network/issues/3, I guess).
