### PR TITLE
Return pipe number after executing whatHappened()

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -587,7 +587,7 @@ bool RF24::read( void* buf, uint8_t len )
 
 /****************************************************************************/
 
-void RF24::whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready)
+uint8_t RF24::whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready)
 {
   // Read the status & reset the status in one easy call
   // Or is that such a good idea?
@@ -597,6 +597,10 @@ void RF24::whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready)
   tx_ok = status & _BV(TX_DS);
   tx_fail = status & _BV(MAX_RT);
   rx_ready = status & _BV(RX_DR);
+    
+  // Return pipe number. However, it is only useful and valid when 
+  // something is received (rx_ready == true)
+  return ( status >> RX_P_NO ) & B111;
 }
 
 /****************************************************************************/

--- a/RF24.h
+++ b/RF24.h
@@ -612,8 +612,10 @@ public:
    * @param[out] tx_ok The send was successful (TX_DS)
    * @param[out] tx_fail The send failed, too many retries (MAX_RT)
    * @param[out] rx_ready There is a message waiting to be read (RX_DS)
+   *
+   * @return Pipe number for which data is ready. Only valid if rx_ready == true
    */
-  void whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready);
+  uint8_t whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready);
 
   /**
    * Test whether there was a carrier on the line for the


### PR DESCRIPTION
Hi maniacbug,

I'm using your RF24, RF24Network and FreeRTOS libraries together with interrupts for the RF24. To keep interrupt routines short, I modified `whatHappened()` to return the pipe number for which data is available. This way, a modified `RF24Network::update()` does not have to poll all pipes for data in a separate task, but the `RF24Network::update()` routine can be executed directly. Of course, the return value of `whatHappened()` is only valid (and of use) when `tx_ready` is true.

Please review my change. Hopefully it could be of use!

Kind regards,
BasilFX
