### PR TITLE
Ported it to c without arduino dependencies. Switched from printf to a simple uart library.

### DIFF
--- a/RF24.c
+++ b/RF24.c
@@ -1,5 +1,5 @@
 /*
-   Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+   Copyright (C) 2011,2012 J. Coliz <maniacbug@ymail.com>, jaseg <s@jaseg.de>
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -9,6 +9,35 @@
 #include "nRF24L01.h"
 #include "RF24_config.h"
 #include "RF24.h"
+#include "uart.h"
+#include "util.h"
+
+#include <avr/io.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <avr/pgmspace.h>
+#include <util/delay.h>
+
+
+#undef SERIAL_DEBUG
+#ifdef SERIAL_DEBUG
+#define IF_SERIAL_DEBUG(x) ({x;})
+#else
+#define IF_SERIAL_DEBUG(x)
+#endif
+
+
+//Global status variables
+uint8_t nrf24_wide_band = TRUE; /* 2Mbs data rate in use? */
+uint8_t nrf24_p_variant = FALSE; /* False for RF24L01 and TRUE for RF24L01P */
+uint8_t nrf24_payload_size = 32; /**< Fixed size of payloads */
+uint8_t nrf24_ack_payload_available = FALSE; /**< Whether there is an ack payload waiting */
+uint8_t nrf24_dynamic_payloads_enabled = FALSE; /**< Whether dynamic payloads are enabled. */ 
+uint8_t nrf24_ack_payload_length; /**< Dynamic size of pending ack payload. */
+uint64_t nrf24_pipe0_reading_address = 0; /**< Last address set on pipe 0 for reading. */
+
 
 inline void nrf24_csn(int mode)
 {
@@ -27,40 +56,40 @@ inline void nrf24_ce(int level)
     CE_PORT |= level<<CE_PIN;
 }
 
-uint8_t nrf24_read_register(uint8_t reg, uint8_t* buf, uint8_t len)
+uint8_t nrf24_read_register_buf(uint8_t reg, uint8_t* buf, uint8_t len)
 {
     uint8_t status;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( R_REGISTER | ( REGISTER_MASK & reg ) );
     while ( len-- )
         *buf++ = spi_transfer(0xff);
 
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
 
 uint8_t nrf24_read_register(uint8_t reg)
 {
-    csn(LOW);
+    nrf24_csn(LOW);
     spi_transfer( R_REGISTER | ( REGISTER_MASK & reg ) );
     uint8_t result = spi_transfer(0xff);
 
-    csn(HIGH);
+    nrf24_csn(HIGH);
     return result;
 }
 
-uint8_t nrf24_write_register(uint8_t reg, const uint8_t* buf, uint8_t len)
+uint8_t nrf24_write_register_buf(uint8_t reg, const uint8_t* buf, uint8_t len)
 {
     uint8_t status;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( W_REGISTER | ( REGISTER_MASK & reg ) );
     while ( len-- )
         spi_transfer(*buf++);
 
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -70,7 +99,7 @@ uint8_t nrf24_write_register(uint8_t reg, uint8_t value)
     uint8_t status;
 
 #ifdef SERIAL_DEBUG
-    uart_puts_p(PSTR("RF24 write_register("));
+    uart_puts_p(PSTR("RF24 nrf24_write_register("));
     uart_puthex(reg);
     uart_putc(',');
     uart_puthex(value);
@@ -78,10 +107,10 @@ uint8_t nrf24_write_register(uint8_t reg, uint8_t value)
     uart_putc('\n');
 #endif
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( W_REGISTER | ( REGISTER_MASK & reg ) );
     spi_transfer(value);
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -92,18 +121,18 @@ uint8_t nrf24_write_payload(const void* buf, uint8_t len)
 
     const uint8_t* current = (const uint8_t*)(buf);
 
-    uint8_t data_len = min(len,payload_size);
-    uint8_t blank_len = dynamic_payloads_enabled ? 0 : payload_size - data_len;
+    uint8_t data_len = min(len,nrf24_payload_size);
+    uint8_t blank_len = nrf24_dynamic_payloads_enabled ? 0 : nrf24_payload_size - data_len;
 
     //printf("[Writing %u bytes %u blanks]",data_len,blank_len);
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( W_TX_PAYLOAD );
     while ( data_len-- )
         spi_transfer(*current++);
     while ( blank_len-- )
         spi_transfer(0);
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -113,18 +142,18 @@ uint8_t nrf24_read_payload(void* buf, uint8_t len)
     uint8_t status;
     uint8_t* current = (uint8_t*)(buf);
 
-    uint8_t data_len = min(len,payload_size);
-    uint8_t blank_len = dynamic_payloads_enabled ? 0 : payload_size - data_len;
+    uint8_t data_len = min(len,nrf24_payload_size);
+    uint8_t blank_len = nrf24_dynamic_payloads_enabled ? 0 : nrf24_payload_size - data_len;
 
     //printf("[Reading %u bytes %u blanks]",data_len,blank_len);
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( R_RX_PAYLOAD );
     while ( data_len-- )
         *current++ = spi_transfer(0xff);
     while ( blank_len-- )
         spi_transfer(0xff);
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -133,9 +162,9 @@ uint8_t nrf24_flush_rx(void)
 {
     uint8_t status;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( FLUSH_RX );
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -144,9 +173,9 @@ uint8_t nrf24_flush_tx(void)
 {
     uint8_t status;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( FLUSH_TX );
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -155,9 +184,9 @@ uint8_t nrf24_get_status(void)
 {
     uint8_t status;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     status = spi_transfer( NOP );
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return status;
 }
@@ -177,7 +206,6 @@ void nrf24_print_status(uint8_t status)
     uart_puts_p(PSTR("TX_FULL="));
     uart_putc((status & _BV(TX_FULL))?'1':'0');
     uart_putc('\n');
-
 }
 
 void nrf24_print_observe_tx(uint8_t value)
@@ -191,11 +219,12 @@ void nrf24_print_observe_tx(uint8_t value)
     uart_putc('\n');
 }
 
-
-
 void nrf24_print_byte_register(const char* name, uint8_t reg, uint8_t qty)
 {
-    uart_puts_p("RF24 ");
+    if(!qty){
+        qty = 1;
+    }
+    uart_puts_p(PSTR("RF24 "));
     uart_puts(name);
     uart_putc('\t');
     if(strlen_P(name) < 8){
@@ -207,16 +236,17 @@ void nrf24_print_byte_register(const char* name, uint8_t reg, uint8_t qty)
         uart_putc(' ');
         uart_putc('0');
         uart_putc('x');
-        uart_puthex(read_register(reg++));
+        uart_puthex(nrf24_read_register(reg++));
     }
     uart_putc('\n');
 }
 
-
-
 void nrf24_print_address_register(const char* name, uint8_t reg, uint8_t qty)
 {
-    uart_puts_p("RF24 ");
+    if(!qty){
+        qty = 1;
+    }
+    uart_puts_p(PSTR("RF24 "));
     uart_puts(name);
     uart_putc('\t');
     if(strlen_P(name) < 8){
@@ -227,7 +257,7 @@ void nrf24_print_address_register(const char* name, uint8_t reg, uint8_t qty)
     while (qty--)
     {
         uint8_t buffer[5];
-        read_register(reg++,buffer,sizeof(buffer));
+        nrf24_read_register_buf(reg++,buffer,sizeof(buffer));
         uart_putc(' ');
         uart_putc('0');
         uart_putc('x');
@@ -244,25 +274,23 @@ void nrf24_print_address_register(const char* name, uint8_t reg, uint8_t qty)
 void nrf24_setChannel(uint8_t channel)
 {
     // TODO: This method could take advantage of the 'wide_band' calculation
-    // done in setChannel() to require certain channel spacing.
+    // done in nrf24_setChannel() to require nrf24_certain channel spacing.
 
-    const uint8_t max_channel = 127;
-    write_register(RF_CH,min(channel,max_channel));
+    nrf24_write_register(RF_CH,min(channel,127));
 }
 
 
 
 void nrf24_setPayloadSize(uint8_t size)
 {
-    const uint8_t max_payload_size = 32;
-    payload_size = min(size,max_payload_size);
+    nrf24_payload_size = min(size,MAX_PAYLOAD_SIZE);
 }
 
 
 
 uint8_t nrf24_getPayloadSize(void)
 {
-    return payload_size;
+    return nrf24_payload_size;
 }
 
 
@@ -302,31 +330,31 @@ static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = {
 
 void nrf24_printDetails(void)
 {
-    print_status(get_status());
+    nrf24_print_status(nrf24_get_status());
 
-    print_address_register(PSTR("RX_ADDR_P0-1"),RX_ADDR_P0,2);
-    print_byte_register(PSTR("RX_ADDR_P2-5"),RX_ADDR_P2,4);
-    print_address_register(PSTR("TX_ADDR"),TX_ADDR);
+    nrf24_print_address_register(PSTR("RX_ADDR_P0-1"),RX_ADDR_P0,2);
+    nrf24_print_byte_register(PSTR("RX_ADDR_P2-5"),RX_ADDR_P2,4);
+    nrf24_print_address_register(PSTR("TX_ADDR"),TX_ADDR,1);
 
-    print_byte_register(PSTR("RX_PW_P0-6"),RX_PW_P0,6);
-    print_byte_register(PSTR("EN_AA"),EN_AA);
-    print_byte_register(PSTR("EN_RXADDR"),EN_RXADDR);
-    print_byte_register(PSTR("RF_CH"),RF_CH);
-    print_byte_register(PSTR("RF_SETUP"),RF_SETUP);
-    print_byte_register(PSTR("CONFIG"),CONFIG);
-    print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
+    nrf24_print_byte_register(PSTR("RX_PW_P0-6"),RX_PW_P0,6);
+    nrf24_print_byte_register(PSTR("EN_AA"),EN_AA,1);
+    nrf24_print_byte_register(PSTR("EN_RXADDR"),EN_RXADDR,1);
+    nrf24_print_byte_register(PSTR("RF_CH"),RF_CH,1);
+    nrf24_print_byte_register(PSTR("RF_SETUP"),RF_SETUP,1);
+    nrf24_print_byte_register(PSTR("CONFIG"),CONFIG,1);
+    nrf24_print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
 
     uart_puts_p(PSTR("RF24 Data Rate\t = "));
-    uart_puts(pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
+    uart_puts_p((const char*)pgm_read_word(&rf24_datarate_e_str_P[nrf24_getDataRate()]));
     uart_putc('\n');
     uart_puts_p(PSTR("RF24 Model\t\t = "));
-    uart_puts(pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
+    uart_puts_p((const char*)pgm_read_word(&rf24_model_e_str_P[nrf24_isPVariant()]));
     uart_putc('\n');
     uart_puts_p(PSTR("RF24 CRC Length\t = "));
-    uart_puts(pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
+    uart_puts_p((const char*)pgm_read_word(&rf24_crclength_e_str_P[nrf24_getCRCLength()]));
     uart_putc('\n');
     uart_puts_p(PSTR("RF24 PA Power\t = "));
-    uart_puts(pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+    uart_puts_p((const char*)pgm_read_word(&rf24_pa_dbm_e_str_P[nrf24_getPALevel()]));
     uart_putc('\n');
 }
 
@@ -341,8 +369,8 @@ void nrf24_begin(void)
     // Initialize SPI bus
     spi_begin();
 
-    ce(LOW);
-    csn(HIGH);
+    nrf24_ce(LOW);
+    nrf24_csn(HIGH);
 
     // Must allow the radio time to settle else configuration bits will not necessarily stick.
     // This is actually only required following power up but some settling time also appears to
@@ -350,106 +378,107 @@ void nrf24_begin(void)
     // Enabling 16b CRC is by far the most obvious case if the wrong timing is used - or skipped.
     // Technically we require 4.5ms + 14us as a worst case. We'll just call it 5ms for good measure.
     // WARNING: Delay is based on P-variant whereby non-P *may* require different timing.
-    delay( 5 ) ;
+    _delay_ms( 5 ) ;
 
     // Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to make testing a little easier
     // WARNING: If this is ever lowered, either 250KBS mode with AA is broken or maximum packet
     // sizes must never be used. See documentation for a more complete explanation.
-    write_register(SETUP_RETR,(B0100 << ARD) | (B1111 << ARC));
+    nrf24_write_register(SETUP_RETR,(0x4 << ARD) | (0xF << ARC));
 
     // Restore our default PA level
-    setPALevel( RF24_PA_MAX ) ;
+    nrf24_setPALevel( RF24_PA_MAX ) ;
 
     // Determine if this is a p or non-p RF24 module and then
     // reset our data rate back to default value. This works
     // because a non-P variant won't allow the data rate to
     // be set to 250Kbps.
-    if( setDataRate( RF24_250KBPS ) )
+    if( nrf24_setDataRate( RF24_250KBPS ) )
     {
-        p_variant = true ;
+        nrf24_p_variant = TRUE ;
     }
 
     // Then set the data rate to the slowest (and most reliable) speed supported by all
     // hardware.
-    setDataRate( RF24_1MBPS ) ;
+    nrf24_setDataRate( RF24_1MBPS ) ;
 
     // Initialize CRC and request 2-byte (16bit) CRC
-    setCRCLength( RF24_CRC_16 ) ;
+    nrf24_setCRCLength( RF24_CRC_16 ) ;
 
     // Disable dynamic payloads, to match dynamic_payloads_enabled setting
-    write_register(DYNPD,0);
+    nrf24_write_register(DYNPD,0);
 
     // Reset current status
-    // Notice reset and flush is the last thing we do
-    write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+    // Notice reset and nrf24_flush is the last thing we do
+    nrf24_write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
 
     // Set up default configuration.  Callers can always change it later.
     // This channel should be universally safe and not bleed over into adjacent
     // spectrum.
-    setChannel(76);
+    nrf24_setChannel(76);
 
     // Flush buffers
-    flush_rx();
-    flush_tx();
+    nrf24_flush_rx();
+    nrf24_flush_tx();
 }
 
 
 
 void nrf24_startListening(void)
 {
-    write_register(CONFIG, read_register(CONFIG) | _BV(PWR_UP) | _BV(PRIM_RX));
-    write_register(STATUS, _BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+    nrf24_write_register(CONFIG, nrf24_read_register(CONFIG) | _BV(PWR_UP) | _BV(PRIM_RX));
+    nrf24_write_register(STATUS, _BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
 
     // Restore the pipe0 adddress, if exists
-    if (pipe0_reading_address)
-        write_register(RX_ADDR_P0, (const uint8_t*)(pipe0_reading_address), 5);
+    if (nrf24_pipe0_reading_address)
+        nrf24_write_register_buf(RX_ADDR_P0, (const uint8_t*)(&nrf24_pipe0_reading_address), 5);
 
     // Flush buffers
-    flush_rx();
-    flush_tx();
+    nrf24_flush_rx();
+    nrf24_flush_tx();
 
     // Go!
-    ce(HIGH);
+    nrf24_ce(HIGH);
 
     // wait for the radio to come up (130us actually only needed)
-    delayMicroseconds(130);
+    _delay_us(130);
 }
 
 
 
 void nrf24_stopListening(void)
 {
-    ce(LOW);
-    flush_tx();
-    flush_rx();
+    nrf24_ce(LOW);
+    nrf24_flush_tx();
+    nrf24_flush_rx();
 }
 
 
 
 void nrf24_powerDown(void)
 {
-    write_register(CONFIG,read_register(CONFIG) & ~_BV(PWR_UP));
+    nrf24_write_register(CONFIG,nrf24_read_register(CONFIG) & ~_BV(PWR_UP));
 }
 
 
 
 void nrf24_powerUp(void)
 {
-    write_register(CONFIG,read_register(CONFIG) | _BV(PWR_UP));
+    nrf24_write_register(CONFIG,nrf24_read_register(CONFIG) | _BV(PWR_UP));
 }
 
 
 
-bool nrf24_write( const void* buf, uint8_t len )
+uint8_t nrf24_write( const void* buf, uint8_t len )
 {
-    bool result = false;
+    uint8_t result = FALSE;
 
     // Begin the write
-    startWrite(buf,len);
+    nrf24_startWrite(buf,len);
 
     // ------------
     // At this point we could return from a non-blocking write, and then call
     // the rest after an interrupt
+    // FIXME
 
     // Instead, we are going to block here until we get TX_DS (transmission completed and ack'd)
     // or MAX_RT (maximum retries, transmission failed).  Also, we'll timeout in case the radio
@@ -460,14 +489,15 @@ bool nrf24_write( const void* buf, uint8_t len )
     // Monitor the send
     uint8_t observe_tx;
     uint8_t status;
-    uint32_t sent_at = millis();
-    const uint32_t timeout = 500; //ms to wait for timeout
+    const uint32_t timeout = 500000; //ms to wait for timeout
+    uint32_t cycles = 0;
     do
     {
-        status = read_register(OBSERVE_TX,&observe_tx,1);
+        status = nrf24_read_register_buf(OBSERVE_TX,&observe_tx,1);
         IF_SERIAL_DEBUG(uart_puthex(observe_tx));
+        cycles++;
     }
-    while( ! ( status & ( _BV(TX_DS) | _BV(MAX_RT) ) ) && ( millis() - sent_at < timeout ) );
+    while( ! ( status & ( _BV(TX_DS) | _BV(MAX_RT) ) ) && ( cycles < timeout ) );
 
     // The part above is what you could recreate with your own interrupt handler,
     // and then call this when you got an interrupt
@@ -478,8 +508,8 @@ bool nrf24_write( const void* buf, uint8_t len )
     // * The send was successful (TX_DS)
     // * The send failed, too many retries (MAX_RT)
     // * There is an ack packet waiting (RX_DR)
-    bool tx_ok, tx_fail;
-    whatHappened(tx_ok,tx_fail,ack_payload_available);
+    uint8_t tx_ok=0, tx_fail=0;
+    nrf24_whatHappened(tx_ok,tx_fail,nrf24_ack_payload_available);
 
     //printf("%u%u%u\r\n",tx_ok,tx_fail,ack_payload_available);
 
@@ -487,9 +517,9 @@ bool nrf24_write( const void* buf, uint8_t len )
     IF_SERIAL_DEBUG(uart_puts(result?"...OK.":"...Failed"));
 
     // Handle the ack packet
-    if ( ack_payload_available )
+    if ( nrf24_ack_payload_available )
     {
-        ack_payload_length = getDynamicPayloadSize();
+        nrf24_ack_payload_length = nrf24_getDynamicPayloadSize();
 #ifdef SERIAL_DEBUG
         uart_puts_p(PSTR("RF24 [AckPacket]/"));
         uart_putdec(uart_ack_payload_length);
@@ -500,10 +530,10 @@ bool nrf24_write( const void* buf, uint8_t len )
     // Yay, we are done.
 
     // Power down
-    powerDown();
+    nrf24_powerDown();
 
     // Flush buffers (Is this a relic of past experimentation, and not needed anymore??)
-    flush_tx();
+    nrf24_flush_tx();
 
     return result;
 }
@@ -512,16 +542,16 @@ bool nrf24_write( const void* buf, uint8_t len )
 void nrf24_startWrite( const void* buf, uint8_t len )
 {
     // Transmitter power-up
-    write_register(CONFIG, ( read_register(CONFIG) | _BV(PWR_UP) ) & ~_BV(PRIM_RX) );
-    delayMicroseconds(150);
+    nrf24_write_register(CONFIG, ( nrf24_read_register(CONFIG) | _BV(PWR_UP) ) & ~_BV(PRIM_RX) );
+    _delay_us(150);
 
     // Send the payload
-    write_payload( buf, len );
+    nrf24_write_payload( buf, len );
 
     // Allons!
-    ce(HIGH);
-    delayMicroseconds(15);
-    ce(LOW);
+    nrf24_ce(HIGH);
+    _delay_us(15);
+    nrf24_ce(LOW);
 }
 
 
@@ -530,49 +560,49 @@ uint8_t nrf24_getDynamicPayloadSize(void)
 {
     uint8_t result = 0;
 
-    csn(LOW);
+    nrf24_csn(LOW);
     spi_transfer( R_RX_PL_WID );
     result = spi_transfer(0xff);
-    csn(HIGH);
+    nrf24_csn(HIGH);
 
     return result;
 }
 
 
 
-bool nrf24_available(void)
+uint8_t nrf24_available(void)
 {
-    return available(NULL);
+    return nrf24_available_pipe(NULL);
 }
 
 
 
-bool nrf24_available(uint8_t* pipe_num)
+uint8_t nrf24_available_pipe(uint8_t* pipe_num)
 {
-    uint8_t status = get_status();
+    uint8_t status = nrf24_get_status();
 
     // Too noisy, enable if you really want lots o data!!
     //IF_SERIAL_DEBUG(print_status(status));
 
-    bool result = ( status & _BV(RX_DR) );
+    uint8_t result = ( status & _BV(RX_DR) );
 
     if (result)
     {
         // If the caller wants the pipe number, include that
         if ( pipe_num )
-            *pipe_num = ( status >> RX_P_NO ) & B111;
+            *pipe_num = ( status >> RX_P_NO ) & 7;
 
         // Clear the status bit
 
         // ??? Should this REALLY be cleared now?  Or wait until we
         // actually READ the payload?
 
-        write_register(STATUS,_BV(RX_DR) );
+        nrf24_write_register(STATUS,_BV(RX_DR) );
 
         // Handle ack payload receipt
         if ( status & _BV(TX_DS) )
         {
-            write_register(STATUS,_BV(TX_DS));
+            nrf24_write_register(STATUS,_BV(TX_DS));
         }
     }
 
@@ -581,22 +611,22 @@ bool nrf24_available(uint8_t* pipe_num)
 
 
 
-bool nrf24_read( void* buf, uint8_t len )
+uint8_t nrf24_read( void* buf, uint8_t len )
 {
     // Fetch the payload
-    read_payload( buf, len );
+    nrf24_read_payload( buf, len );
 
     // was this the last of the data available?
-    return read_register(FIFO_STATUS) & _BV(RX_EMPTY);
+    return nrf24_read_register(FIFO_STATUS) & _BV(RX_EMPTY);
 }
 
 
 
-void nrf24_whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready)
+void nrf24_whatHappened(uint8_t tx_ok, uint8_t tx_fail, uint8_t rx_ready)
 {
     // Read the status & reset the status in one easy call
     // Or is that such a good idea?
-    uint8_t status = write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
+    uint8_t status = nrf24_write_register(STATUS,_BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
 
     // Report to the user what happened
     tx_ok = status & _BV(TX_DS);
@@ -611,11 +641,10 @@ void nrf24_openWritingPipe(uint64_t value)
     // Note that AVR 8-bit uC's store this LSB first, and the NRF24L01(+)
     // expects it LSB first too, so we're good.
 
-    write_register(RX_ADDR_P0, (uint8_t*)(&value), 5);
-    write_register(TX_ADDR, (uint8_t*)(&value), 5);
+    nrf24_write_register_buf(RX_ADDR_P0, (uint8_t*)(&value), 5);
+    nrf24_write_register_buf(TX_ADDR, (uint8_t*)(&value), 5);
 
-    const uint8_t max_payload_size = 32;
-    write_register(RX_PW_P0,min(payload_size,max_payload_size));
+    nrf24_write_register(RX_PW_P0,min(nrf24_payload_size,MAX_PAYLOAD_SIZE));
 }
 
 
@@ -639,22 +668,22 @@ void nrf24_openReadingPipe(uint8_t child, uint64_t address)
     // openWritingPipe() will overwrite the pipe 0 address, so
     // startListening() will have to restore it.
     if (child == 0)
-        pipe0_reading_address = address;
+        nrf24_pipe0_reading_address = address;
 
     if (child <= 6)
     {
         // For pipes 2-5, only write the LSB
         if ( child < 2 )
-            write_register(pgm_read_byte(&child_pipe[child]), (const uint8_t*)(&address), 5);
+            nrf24_write_register_buf(pgm_read_byte(&child_pipe[child]), (const uint8_t*)(&address), 5);
         else
-            write_register(pgm_read_byte(&child_pipe[child]), (const uint8_t*)(&address), 1);
+            nrf24_write_register_buf(pgm_read_byte(&child_pipe[child]), (const uint8_t*)(&address), 1);
 
-        write_register(pgm_read_byte(&child_payload_size[child]),payload_size);
+        nrf24_write_register(pgm_read_byte(&child_payload_size[child]), nrf24_payload_size);
 
         // Note it would be more efficient to set all of the bits for all open
         // pipes at once.  However, I thought it would make the calling code
         // more simple to do it this way.
-        write_register(EN_RXADDR,read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[child])));
+        nrf24_write_register(EN_RXADDR,nrf24_read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[child])));
     }
 }
 
@@ -662,10 +691,10 @@ void nrf24_openReadingPipe(uint8_t child, uint64_t address)
 
 void nrf24_toggle_features(void)
 {
-    csn(LOW);
+    nrf24_csn(LOW);
     spi_transfer( ACTIVATE );
     spi_transfer( 0x73 );
-    csn(HIGH);
+    nrf24_csn(HIGH);
 }
 
 
@@ -673,14 +702,14 @@ void nrf24_toggle_features(void)
 void nrf24_enableDynamicPayloads(void)
 {
     // Enable dynamic payload throughout the system
-    write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
+    nrf24_write_register(FEATURE,nrf24_read_register(FEATURE) | _BV(EN_DPL) );
 
     // If it didn't work, the features are not enabled
-    if ( ! read_register(FEATURE) )
+    if ( ! nrf24_read_register(FEATURE) )
     {
         // So enable them and try again
-        toggle_features();
-        write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
+        nrf24_toggle_features();
+        nrf24_write_register(FEATURE,nrf24_read_register(FEATURE) | _BV(EN_DPL) );
     }
 
 #ifdef SERIAL_DEBUG
@@ -691,11 +720,11 @@ void nrf24_enableDynamicPayloads(void)
 
     // Enable dynamic payload on all pipes
     //
-    // Not sure the use case of only having dynamic payload on certain
+    // Not sure the use case of only having dynamic payload on nrf24_certain
     // pipes, so the library does not support it.
-    write_register(DYNPD,read_register(DYNPD) | _BV(DPL_P5) | _BV(DPL_P4) | _BV(DPL_P3) | _BV(DPL_P2) | _BV(DPL_P1) | _BV(DPL_P0));
+    nrf24_write_register(DYNPD,nrf24_read_register(DYNPD) | _BV(DPL_P5) | _BV(DPL_P4) | _BV(DPL_P3) | _BV(DPL_P2) | _BV(DPL_P1) | _BV(DPL_P0));
 
-    dynamic_payloads_enabled = true;
+    nrf24_dynamic_payloads_enabled = TRUE;
 }
 
 
@@ -706,14 +735,14 @@ void nrf24_enableAckPayload(void)
     // enable ack payload and dynamic payload features
     //
 
-    write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
+    nrf24_write_register(FEATURE,nrf24_read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
 
     // If it didn't work, the features are not enabled
-    if ( ! read_register(FEATURE) )
+    if ( ! nrf24_read_register(FEATURE) )
     {
         // So enable them and try again
-        toggle_features();
-        write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
+        nrf24_toggle_features();
+        nrf24_write_register(FEATURE,nrf24_read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
     }
 
 #ifdef SERIAL_DEBUG
@@ -726,7 +755,7 @@ void nrf24_enableAckPayload(void)
     // Enable dynamic payload on pipes 0 & 1
     //
 
-    write_register(DYNPD,read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
+    nrf24_write_register(DYNPD,nrf24_read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
 }
 
 
@@ -735,49 +764,48 @@ void nrf24_writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
 {
     const uint8_t* current = (const uint8_t*)(buf);
 
-    csn(LOW);
-    spi_transfer( W_ACK_PAYLOAD | ( pipe & B111 ) );
-    const uint8_t max_payload_size = 32;
-    uint8_t data_len = min(len,max_payload_size);
+    nrf24_csn(LOW);
+    spi_transfer( W_ACK_PAYLOAD | ( pipe & 7 ) );
+    uint8_t data_len = min(len,MAX_PAYLOAD_SIZE);
     while ( data_len-- )
         spi_transfer(*current++);
 
-    csn(HIGH);
+    nrf24_csn(HIGH);
 }
 
 
 
-bool nrf24_isAckPayloadAvailable(void)
+uint8_t nrf24_isAckPayloadAvailable(void)
 {
-    bool result = ack_payload_available;
-    ack_payload_available = false;
+    uint8_t result = nrf24_ack_payload_available;
+    nrf24_ack_payload_available = FALSE;
     return result;
 }
 
 
 
-bool nrf24_isPVariant(void)
+uint8_t nrf24_isPVariant(void)
 {
-    return p_variant ;
+    return nrf24_p_variant ;
 }
 
 
 
-void nrf24_setAutoAck(bool enable)
+void nrf24_setAutoAck(uint8_t enable)
 {
     if ( enable )
-        write_register(EN_AA, 0x3F);
+        nrf24_write_register(EN_AA, 0x3F);
     else
-        write_register(EN_AA, 0);
+        nrf24_write_register(EN_AA, 0);
 }
 
 
 
-void nrf24_setAutoAck( uint8_t pipe, bool enable )
+void nrf24_setAutoAck_pipe( uint8_t pipe, uint8_t enable )
 {
     if ( pipe <= 6 )
     {
-        uint8_t en_aa = read_register( EN_AA ) ;
+        uint8_t en_aa = nrf24_read_register( EN_AA ) ;
         if( enable )
         {
             en_aa |= _BV(pipe) ;
@@ -786,29 +814,29 @@ void nrf24_setAutoAck( uint8_t pipe, bool enable )
         {
             en_aa &= ~_BV(pipe) ;
         }
-        write_register( EN_AA, en_aa ) ;
+        nrf24_write_register( EN_AA, en_aa ) ;
     }
 }
 
 
 
-bool nrf24_testCarrier(void)
+uint8_t nrf24_testCarrier(void)
 {
-    return ( read_register(CD) & 1 );
+    return ( nrf24_read_register(CD) & 1 );
 }
 
 
 
-bool nrf24_testRPD(void)
+uint8_t nrf24_testRPD(void)
 {
-    return ( read_register(RPD) & 1 ) ;
+    return ( nrf24_read_register(RPD) & 1 ) ;
 }
 
 
 
 void nrf24_setPALevel(rf24_pa_dbm_e level)
 {
-    uint8_t setup = read_register(RF_SETUP) ;
+    uint8_t setup = nrf24_read_register(RF_SETUP) ;
     setup &= ~(_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
 
     // switch uses RAM (evil!)
@@ -834,7 +862,7 @@ void nrf24_setPALevel(rf24_pa_dbm_e level)
         setup |= (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
     }
 
-    write_register( RF_SETUP, setup ) ;
+    nrf24_write_register( RF_SETUP, setup ) ;
 }
 
 
@@ -842,7 +870,7 @@ void nrf24_setPALevel(rf24_pa_dbm_e level)
 rf24_pa_dbm_e nrf24_getPALevel(void)
 {
     rf24_pa_dbm_e result = RF24_PA_ERROR ;
-    uint8_t power = read_register(RF_SETUP) & (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
+    uint8_t power = nrf24_read_register(RF_SETUP) & (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) ;
 
     // switch uses RAM (evil!)
     if ( power == (_BV(RF_PWR_LOW) | _BV(RF_PWR_HIGH)) )
@@ -867,19 +895,18 @@ rf24_pa_dbm_e nrf24_getPALevel(void)
 
 
 
-bool nrf24_setDataRate(rf24_datarate_e speed)
+uint8_t nrf24_setDataRate(rf24_datarate_e speed)
 {
-    bool result = false;
-    uint8_t setup = read_register(RF_SETUP) ;
+    uint8_t setup = nrf24_read_register(RF_SETUP) ;
 
     // HIGH and LOW '00' is 1Mbs - our default
-    wide_band = false ;
+    nrf24_wide_band = FALSE ;
     setup &= ~(_BV(RF_DR_LOW) | _BV(RF_DR_HIGH)) ;
     if( speed == RF24_250KBPS )
     {
         // Must set the RF_DR_LOW to 1; RF_DR_HIGH (used to be RF_DR) is already 0
         // Making it '10'.
-        wide_band = false ;
+        nrf24_wide_band = FALSE ;
         setup |= _BV( RF_DR_LOW ) ;
     }
     else
@@ -888,28 +915,25 @@ bool nrf24_setDataRate(rf24_datarate_e speed)
         // Making it '01'
         if ( speed == RF24_2MBPS )
         {
-            wide_band = true ;
+            nrf24_wide_band = TRUE ;
             setup |= _BV(RF_DR_HIGH);
         }
         else
         {
             // 1Mbs
-            wide_band = false ;
+            nrf24_wide_band = FALSE ;
         }
     }
-    write_register(RF_SETUP,setup);
+    nrf24_write_register(RF_SETUP,setup);
 
     // Verify our result
-    if ( read_register(RF_SETUP) == setup )
-    {
-        result = true;
+    if ( nrf24_read_register(RF_SETUP) == setup ){
+        return TRUE;
     }
-    else
-    {
-        wide_band = false;
+    else{
+        nrf24_wide_band = FALSE;
     }
-
-    return result;
+    return FALSE;
 }
 
 
@@ -917,7 +941,7 @@ bool nrf24_setDataRate(rf24_datarate_e speed)
 rf24_datarate_e nrf24_getDataRate( void )
 {
     rf24_datarate_e result ;
-    uint8_t dr = read_register(RF_SETUP) & (_BV(RF_DR_LOW) | _BV(RF_DR_HIGH));
+    uint8_t dr = nrf24_read_register(RF_SETUP) & (_BV(RF_DR_LOW) | _BV(RF_DR_HIGH));
 
     // switch uses RAM (evil!)
     // Order matters in our case below
@@ -943,7 +967,7 @@ rf24_datarate_e nrf24_getDataRate( void )
 
 void nrf24_setCRCLength(rf24_crclength_e length)
 {
-    uint8_t config = read_register(CONFIG) & ~( _BV(CRCO) | _BV(EN_CRC)) ;
+    uint8_t config = nrf24_read_register(CONFIG) & ~( _BV(CRCO) | _BV(EN_CRC)) ;
 
     // switch uses RAM (evil!)
     if ( length == RF24_CRC_DISABLED )
@@ -959,7 +983,7 @@ void nrf24_setCRCLength(rf24_crclength_e length)
         config |= _BV(EN_CRC);
         config |= _BV( CRCO );
     }
-    write_register( CONFIG, config ) ;
+    nrf24_write_register( CONFIG, config ) ;
 }
 
 
@@ -967,7 +991,7 @@ void nrf24_setCRCLength(rf24_crclength_e length)
 rf24_crclength_e nrf24_getCRCLength(void)
 {
     rf24_crclength_e result = RF24_CRC_DISABLED;
-    uint8_t config = read_register(CONFIG) & ( _BV(CRCO) | _BV(EN_CRC)) ;
+    uint8_t config = nrf24_read_register(CONFIG) & ( _BV(CRCO) | _BV(EN_CRC)) ;
 
     if ( config & _BV(EN_CRC ) )
     {
@@ -984,12 +1008,12 @@ rf24_crclength_e nrf24_getCRCLength(void)
 
 void nrf24_disableCRC( void )
 {
-    uint8_t disable = read_register(CONFIG) & ~_BV(EN_CRC) ;
-    write_register( CONFIG, disable ) ;
+    uint8_t disable = nrf24_read_register(CONFIG) & ~_BV(EN_CRC) ;
+    nrf24_write_register( CONFIG, disable ) ;
 }
 
 
 void nrf24_setRetries(uint8_t delay, uint8_t count)
 {
-    write_register(SETUP_RETR,(delay&0xf)<<ARD | (count&0xf)<<ARC);
+    nrf24_write_register(SETUP_RETR,(delay&0xf)<<ARD | (count&0xf)<<ARC);
 }

--- a/RF24.h
+++ b/RF24.h
@@ -1,10 +1,10 @@
 /*
- Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+   Copyright (C) 2011,2012 J. Coliz <maniacbug@ymail.com>, jaseg <s@jaseg.de>
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
- */
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   version 2 as published by the Free Software Foundation.
+   */
 
 /**
  * @file RF24.h
@@ -16,6 +16,13 @@
 #define __RF24_H__
 
 #include <RF24_config.h>
+#include "spi.h"
+
+#define HIGH 1
+#define LOW  0
+
+#define TRUE 1
+#define FALSE 0
 
 /**
  * Power Amplifier level.
@@ -42,603 +49,576 @@ typedef enum { RF24_CRC_DISABLED = 0, RF24_CRC_8, RF24_CRC_16 } rf24_crclength_e
  * Driver for nRF24L01(+) 2.4GHz Wireless Transceiver
  */
 
-class RF24
-{
-private:
-  uint8_t ce_pin; /**< "Chip Enable" pin, activates the RX or TX role */
-  uint8_t csn_pin; /**< SPI Chip select */
-  bool wide_band; /* 2Mbs data rate in use? */
-  bool p_variant; /* False for RF24L01 and true for RF24L01P */
-  uint8_t payload_size; /**< Fixed size of payloads */
-  bool ack_payload_available; /**< Whether there is an ack payload waiting */
-  bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */ 
-  uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */
-  uint64_t pipe0_reading_address; /**< Last address set on pipe 0 for reading. */
+/**
+ * @name Low-level internal interface.
+ *
+ *  Protected methods that address the chip directly.  Regular users cannot
+ *  ever call these.  They are documented for completeness and for developers who
+ *  may want to extend this class.
+ */
+/**@{*/
 
-protected:
-  /**
-   * @name Low-level internal interface.
-   *
-   *  Protected methods that address the chip directly.  Regular users cannot
-   *  ever call these.  They are documented for completeness and for developers who
-   *  may want to extend this class.
-   */
-  /**@{*/
+/**
+ * Set chip select pin
+ *
+ * Running SPI bus at PI_CLOCK_DIV2 so we don't waste time transferring data
+ * and best of all, we make use of the radio's FIFO buffers. A lower speed
+ * means we're less likely to effectively leverage our FIFOs and pay a higher
+ * AVR runtime cost as toll.
+ *
+ * @param mode HIGH to take this unit off the SPI bus, LOW to put it on
+ */
+void nrf24_csn(int mode);
 
-  /**
-   * Set chip select pin
-   *
-   * Running SPI bus at PI_CLOCK_DIV2 so we don't waste time transferring data
-   * and best of all, we make use of the radio's FIFO buffers. A lower speed
-   * means we're less likely to effectively leverage our FIFOs and pay a higher
-   * AVR runtime cost as toll.
-   *
-   * @param mode HIGH to take this unit off the SPI bus, LOW to put it on
-   */
-  void csn(int mode);
+/**
+ * Set chip enable
+ *
+ * @param level HIGH to actively begin transmission or LOW to put in standby.  Please see data sheet
+ * for a much more detailed description of this pin.
+ */
+void nrf24_ce(int level);
 
-  /**
-   * Set chip enable
-   *
-   * @param level HIGH to actively begin transmission or LOW to put in standby.  Please see data sheet
-   * for a much more detailed description of this pin.
-   */
-  void ce(int level);
+/**
+ * Read a chunk of data in from a register
+ *
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @param buf Where to put the data
+ * @param len How many bytes of data to transfer
+ * @return Current value of status register
+ */
+uint8_t nrf24_read_register_buf(uint8_t reg, uint8_t* buf, uint8_t len);
 
-  /**
-   * Read a chunk of data in from a register
-   *
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @param buf Where to put the data
-   * @param len How many bytes of data to transfer
-   * @return Current value of status register
-   */
-  uint8_t read_register(uint8_t reg, uint8_t* buf, uint8_t len);
+/**
+ * Read single byte from a register
+ *
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @return Current value of register @p reg
+ */
+uint8_t nrf24_read_register(uint8_t reg);
 
-  /**
-   * Read single byte from a register
-   *
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @return Current value of register @p reg
-   */
-  uint8_t read_register(uint8_t reg);
+/**
+ * Write a chunk of data to a register
+ *
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @param buf Where to get the data
+ * @param len How many bytes of data to transfer
+ * @return Current value of status register
+ */
+uint8_t nrf24_write_register_buf(uint8_t reg, const uint8_t* buf, uint8_t len);
 
-  /**
-   * Write a chunk of data to a register
-   *
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @param buf Where to get the data
-   * @param len How many bytes of data to transfer
-   * @return Current value of status register
-   */
-  uint8_t write_register(uint8_t reg, const uint8_t* buf, uint8_t len);
+/**
+ * Write a single byte to a register
+ *
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @param value The new value to write
+ * @return Current value of status register
+ */
+uint8_t nrf24_write_register(uint8_t reg, uint8_t value);
 
-  /**
-   * Write a single byte to a register
-   *
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @param value The new value to write
-   * @return Current value of status register
-   */
-  uint8_t write_register(uint8_t reg, uint8_t value);
+/**
+ * Write the transmit payload
+ *
+ * The size of data written is the fixed payload size, see getPayloadSize()
+ *
+ * @param buf Where to get the data
+ * @param len Number of bytes to be sent
+ * @return Current value of status register
+ */
+uint8_t nrf24_write_payload(const void* buf, uint8_t len);
 
-  /**
-   * Write the transmit payload
-   *
-   * The size of data written is the fixed payload size, see getPayloadSize()
-   *
-   * @param buf Where to get the data
-   * @param len Number of bytes to be sent
-   * @return Current value of status register
-   */
-  uint8_t write_payload(const void* buf, uint8_t len);
+/**
+ * Read the receive payload
+ *
+ * The size of data read is the fixed payload size, see getPayloadSize()
+ *
+ * @param buf Where to put the data
+ * @param len Maximum number of bytes to read
+ * @return Current value of status register
+ */
+uint8_t nrf24_read_payload(void* buf, uint8_t len);
 
-  /**
-   * Read the receive payload
-   *
-   * The size of data read is the fixed payload size, see getPayloadSize()
-   *
-   * @param buf Where to put the data
-   * @param len Maximum number of bytes to read
-   * @return Current value of status register
-   */
-  uint8_t read_payload(void* buf, uint8_t len);
+/**
+ * Empty the receive buffer
+ *
+ * @return Current value of status register
+ */
+uint8_t nrf24_flush_rx(void);
 
-  /**
-   * Empty the receive buffer
-   *
-   * @return Current value of status register
-   */
-  uint8_t flush_rx(void);
+/**
+ * Empty the transmit buffer
+ *
+ * @return Current value of status register
+ */
+uint8_t nrf24_flush_tx(void);
 
-  /**
-   * Empty the transmit buffer
-   *
-   * @return Current value of status register
-   */
-  uint8_t flush_tx(void);
+/**
+ * Retrieve the current status of the chip
+ *
+ * @return Current value of status register
+ */
+uint8_t nrf24_get_status(void);
 
-  /**
-   * Retrieve the current status of the chip
-   *
-   * @return Current value of status register
-   */
-  uint8_t get_status(void);
+/**
+ * Decode and print the given status to stdout
+ *
+ * @param status Status value to print
+ *
+ * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+ */
+void nrf24_print_status(uint8_t status);
 
-  /**
-   * Decode and print the given status to stdout
-   *
-   * @param status Status value to print
-   *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
-   */
-  void print_status(uint8_t status);
+/**
+ * Decode and print the given 'observe_tx' value to stdout
+ *
+ * @param value The observe_tx value to print
+ *
+ * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+ */
+void nrf24_print_observe_tx(uint8_t value);
 
-  /**
-   * Decode and print the given 'observe_tx' value to stdout
-   *
-   * @param value The observe_tx value to print
-   *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
-   */
-  void print_observe_tx(uint8_t value);
+/**
+ * Print the name and value of an 8-bit register to stdout
+ *
+ * Optionally it can print some quantity of successive
+ * registers on the same line.  This is useful for printing a group
+ * of related registers on one line.
+ *
+ * @param name Name of the register
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @param qty How many successive registers to print
+ */
+void nrf24_print_byte_register(const char* name, uint8_t reg, uint8_t qty);
 
-  /**
-   * Print the name and value of an 8-bit register to stdout
-   *
-   * Optionally it can print some quantity of successive
-   * registers on the same line.  This is useful for printing a group
-   * of related registers on one line.
-   *
-   * @param name Name of the register
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @param qty How many successive registers to print
-   */
-  void print_byte_register(const char* name, uint8_t reg, uint8_t qty = 1);
+/**
+ * Print the name and value of a 40-bit address register to stdout
+ *
+ * Optionally it can print some quantity of successive
+ * registers on the same line.  This is useful for printing a group
+ * of related registers on one line.
+ *
+ * @param name Name of the register
+ * @param reg Which register. Use constants from nRF24L01.h
+ * @param qty How many successive registers to print
+ */
+void nrf24_print_address_register(const char* name, uint8_t reg, uint8_t qty);
 
-  /**
-   * Print the name and value of a 40-bit address register to stdout
-   *
-   * Optionally it can print some quantity of successive
-   * registers on the same line.  This is useful for printing a group
-   * of related registers on one line.
-   *
-   * @param name Name of the register
-   * @param reg Which register. Use constants from nRF24L01.h
-   * @param qty How many successive registers to print
-   */
-  void print_address_register(const char* name, uint8_t reg, uint8_t qty = 1);
+/**
+ * Turn on or off the special features of the chip
+ *
+ * The chip has certain 'features' which are only available when the 'features'
+ * are enabled.  See the datasheet for details.
+ */
+void nrf24_toggle_features(void);
+/**@}*/
 
-  /**
-   * Turn on or off the special features of the chip
-   *
-   * The chip has certain 'features' which are only available when the 'features'
-   * are enabled.  See the datasheet for details.
-   */
-  void toggle_features(void);
-  /**@}*/
+/**
+ * @name Primary public interface
+ *
+ *  These are the main methods you need to operate the chip
+ */
+/**@{*/
 
-public:
-  /**
-   * @name Primary public interface
-   *
-   *  These are the main methods you need to operate the chip
-   */
-  /**@{*/
+/**
+ * Begin operation of the chip
+ *
+ * Call this in setup(), before calling any other methods.
+ */
+void nrf24_begin(void);
 
-  /**
-   * Constructor
-   *
-   * Creates a new instance of this driver.  Before using, you create an instance
-   * and send in the unique pins that this chip is connected to.
-   *
-   * @param _cepin The pin attached to Chip Enable on the RF module
-   * @param _cspin The pin attached to Chip Select
-   */
-  RF24(uint8_t _cepin, uint8_t _cspin);
+/**
+ * Start listening on the pipes opened for reading.
+ *
+ * Be sure to call openReadingPipe() first.  Do not call write() while
+ * in this mode, without first calling stopListening().  Call
+ * isAvailable() to check for incoming traffic, and read() to get it.
+ */
+void nrf24_startListening(void);
 
-  /**
-   * Begin operation of the chip
-   *
-   * Call this in setup(), before calling any other methods.
-   */
-  void begin(void);
+/**
+ * Stop listening for incoming messages
+ *
+ * Do this before calling write().
+ */
+void nrf24_stopListening(void);
 
-  /**
-   * Start listening on the pipes opened for reading.
-   *
-   * Be sure to call openReadingPipe() first.  Do not call write() while
-   * in this mode, without first calling stopListening().  Call
-   * isAvailable() to check for incoming traffic, and read() to get it.
-   */
-  void startListening(void);
+/**
+ * Write to the open writing pipe
+ *
+ * Be sure to call openWritingPipe() first to set the destination
+ * of where to write to.
+ *
+ * This blocks until the message is successfully acknowledged by
+ * the receiver or the timeout/retransmit maxima are reached.  In
+ * the current configuration, the max delay here is 60ms.
+ *
+ * The maximum size of data written is the fixed payload size, see
+ * getPayloadSize().  However, you can write less, and the remainder
+ * will just be filled with zeroes.
+ *
+ * @param buf Pointer to the data to be sent
+ * @param len Number of bytes to be sent
+ * @return True if the payload was delivered successfully FALSE if not
+ */
+uint8_t nrf24_write( const void* buf, uint8_t len );
 
-  /**
-   * Stop listening for incoming messages
-   *
-   * Do this before calling write().
-   */
-  void stopListening(void);
+/**
+ * Test whether there are bytes available to be read
+ *
+ * @return True if there is a payload available, FALSE if none is
+ */
+uint8_t nrf24_available(void);
 
-  /**
-   * Write to the open writing pipe
-   *
-   * Be sure to call openWritingPipe() first to set the destination
-   * of where to write to.
-   *
-   * This blocks until the message is successfully acknowledged by
-   * the receiver or the timeout/retransmit maxima are reached.  In
-   * the current configuration, the max delay here is 60ms.
-   *
-   * The maximum size of data written is the fixed payload size, see
-   * getPayloadSize().  However, you can write less, and the remainder
-   * will just be filled with zeroes.
-   *
-   * @param buf Pointer to the data to be sent
-   * @param len Number of bytes to be sent
-   * @return True if the payload was delivered successfully false if not
-   */
-  bool write( const void* buf, uint8_t len );
+/**
+ * Read the payload
+ *
+ * Return the last payload received
+ *
+ * The size of data read is the fixed payload size, see getPayloadSize()
+ *
+ * @note I specifically chose 'void*' as a data type to make it easier
+ * for beginners to use.  No casting needed.
+ *
+ * @param buf Pointer to a buffer where the data should be written
+ * @param len Maximum number of bytes to read into the buffer
+ * @return True if the payload was delivered successfully FALSE if not
+ */
+uint8_t nrf24_read( void* buf, uint8_t len );
 
-  /**
-   * Test whether there are bytes available to be read
-   *
-   * @return True if there is a payload available, false if none is
-   */
-  bool available(void);
+/**
+ * Open a pipe for writing
+ *
+ * Only one pipe can be open at once, but you can change the pipe
+ * you'll listen to.  Do not call this while actively listening.
+ * Remember to stopListening() first.
+ *
+ * Addresses are 40-bit hex values, e.g.:
+ *
+ * @code
+ *   openWritingPipe(0xF0F0F0F0F0);
+ * @endcode
+ *
+ * @param address The 40-bit address of the pipe to open.  This can be
+ * any value whatsoever, as long as you are the only one writing to it
+ * and only one other radio is listening to it.  Coordinate these pipe
+ * addresses amongst nodes on the network.
+ */
+void nrf24_openWritingPipe(uint64_t address);
 
-  /**
-   * Read the payload
-   *
-   * Return the last payload received
-   *
-   * The size of data read is the fixed payload size, see getPayloadSize()
-   *
-   * @note I specifically chose 'void*' as a data type to make it easier
-   * for beginners to use.  No casting needed.
-   *
-   * @param buf Pointer to a buffer where the data should be written
-   * @param len Maximum number of bytes to read into the buffer
-   * @return True if the payload was delivered successfully false if not
-   */
-  bool read( void* buf, uint8_t len );
+/**
+ * Open a pipe for reading
+ *
+ * Up to 6 pipes can be open for reading at once.  Open all the
+ * reading pipes, and then call startListening().
+ *
+ * @see openWritingPipe
+ *
+ * @warning Pipes 1-5 should share the first 32 bits.
+ * Only the least significant byte should be unique, e.g.
+ * @code
+ *   openReadingPipe(1,0xF0F0F0F0AA);
+ *   openReadingPipe(2,0xF0F0F0F066);
+ * @endcode
+ *
+ * @warning Pipe 0 is also used by the writing pipe.  So if you open
+ * pipe 0 for reading, and then startListening(), it will overwrite the
+ * writing pipe.  Ergo, do an openWritingPipe() again before write().
+ *
+ * @todo Enforce the restriction that pipes 1-5 must share the top 32 bits
+ *
+ * @param number Which pipe# to open, 0-5.
+ * @param address The 40-bit address of the pipe to open.
+ */
+void nrf24_openReadingPipe(uint8_t number, uint64_t address);
 
-  /**
-   * Open a pipe for writing
-   *
-   * Only one pipe can be open at once, but you can change the pipe
-   * you'll listen to.  Do not call this while actively listening.
-   * Remember to stopListening() first.
-   *
-   * Addresses are 40-bit hex values, e.g.:
-   *
-   * @code
-   *   openWritingPipe(0xF0F0F0F0F0);
-   * @endcode
-   *
-   * @param address The 40-bit address of the pipe to open.  This can be
-   * any value whatsoever, as long as you are the only one writing to it
-   * and only one other radio is listening to it.  Coordinate these pipe
-   * addresses amongst nodes on the network.
-   */
-  void openWritingPipe(uint64_t address);
+/**@}*/
+/**
+ * @name Optional Configurators 
+ *
+ *  Methods you can use to get or set the configuration of the chip.
+ *  None are required.  Calling begin() sets up a reasonable set of
+ *  defaults.
+ */
+/**@{*/
+/**
+ * Set the number and delay of retries upon failed submit
+ *
+ * @param delay How long to wait between each retry, in multiples of 250us,
+ * max is 15.  0 means 250us, 15 means 4000us.
+ * @param count How many retries before giving up, max 15
+ */
+void nrf24_setRetries(uint8_t delay, uint8_t count);
 
-  /**
-   * Open a pipe for reading
-   *
-   * Up to 6 pipes can be open for reading at once.  Open all the
-   * reading pipes, and then call startListening().
-   *
-   * @see openWritingPipe
-   *
-   * @warning Pipes 1-5 should share the first 32 bits.
-   * Only the least significant byte should be unique, e.g.
-   * @code
-   *   openReadingPipe(1,0xF0F0F0F0AA);
-   *   openReadingPipe(2,0xF0F0F0F066);
-   * @endcode
-   *
-   * @warning Pipe 0 is also used by the writing pipe.  So if you open
-   * pipe 0 for reading, and then startListening(), it will overwrite the
-   * writing pipe.  Ergo, do an openWritingPipe() again before write().
-   *
-   * @todo Enforce the restriction that pipes 1-5 must share the top 32 bits
-   *
-   * @param number Which pipe# to open, 0-5.
-   * @param address The 40-bit address of the pipe to open.
-   */
-  void openReadingPipe(uint8_t number, uint64_t address);
+/**
+ * Set RF communication channel
+ *
+ * @param channel Which RF channel to communicate on, 0-127
+ */
+void nrf24_setChannel(uint8_t channel);
 
-  /**@}*/
-  /**
-   * @name Optional Configurators 
-   *
-   *  Methods you can use to get or set the configuration of the chip.
-   *  None are required.  Calling begin() sets up a reasonable set of
-   *  defaults.
-   */
-  /**@{*/
-  /**
-   * Set the number and delay of retries upon failed submit
-   *
-   * @param delay How long to wait between each retry, in multiples of 250us,
-   * max is 15.  0 means 250us, 15 means 4000us.
-   * @param count How many retries before giving up, max 15
-   */
-  void setRetries(uint8_t delay, uint8_t count);
+/**
+ * Set Static Payload Size
+ *
+ * This implementation uses a pre-stablished fixed payload size for all
+ * transmissions.  If this method is never called, the driver will always
+ * transmit the maximum payload size (32 bytes), no matter how much
+ * was sent to write().
+ *
+ * @todo Implement variable-sized payloads feature
+ *
+ * @param size The number of bytes in the payload
+ */
+void nrf24_setPayloadSize(uint8_t size);
 
-  /**
-   * Set RF communication channel
-   *
-   * @param channel Which RF channel to communicate on, 0-127
-   */
-  void setChannel(uint8_t channel);
+/**
+ * Get Static Payload Size
+ *
+ * @see setPayloadSize()
+ *
+ * @return The number of bytes in the payload
+ */
+uint8_t nrf24_getPayloadSize(void);
 
-  /**
-   * Set Static Payload Size
-   *
-   * This implementation uses a pre-stablished fixed payload size for all
-   * transmissions.  If this method is never called, the driver will always
-   * transmit the maximum payload size (32 bytes), no matter how much
-   * was sent to write().
-   *
-   * @todo Implement variable-sized payloads feature
-   *
-   * @param size The number of bytes in the payload
-   */
-  void setPayloadSize(uint8_t size);
+/**
+ * Get Dynamic Payload Size
+ *
+ * For dynamic payloads, this pulls the size of the payload off
+ * the chip
+ *
+ * @return Payload length of last-received dynamic payload
+ */
+uint8_t nrf24_getDynamicPayloadSize(void);
 
-  /**
-   * Get Static Payload Size
-   *
-   * @see setPayloadSize()
-   *
-   * @return The number of bytes in the payload
-   */
-  uint8_t getPayloadSize(void);
+/**
+ * Enable custom payloads on the acknowledge packets
+ *
+ * Ack payloads are a handy way to return data back to senders without
+ * manually changing the radio modes on both units.
+ *
+ * @see examples/pingpair_pl/pingpair_pl.pde
+ */
+void nrf24_enableAckPayload(void);
 
-  /**
-   * Get Dynamic Payload Size
-   *
-   * For dynamic payloads, this pulls the size of the payload off
-   * the chip
-   *
-   * @return Payload length of last-received dynamic payload
-   */
-  uint8_t getDynamicPayloadSize(void);
-  
-  /**
-   * Enable custom payloads on the acknowledge packets
-   *
-   * Ack payloads are a handy way to return data back to senders without
-   * manually changing the radio modes on both units.
-   *
-   * @see examples/pingpair_pl/pingpair_pl.pde
-   */
-  void enableAckPayload(void);
+/**
+ * Enable dynamically-sized payloads
+ *
+ * This way you don't always have to send large packets just to send them
+ * once in a while.  This enables dynamic payloads on ALL pipes.
+ *
+ * @see examples/pingpair_pl/pingpair_dyn.pde
+ */
+void nrf24_enableDynamicPayloads(void);
 
-  /**
-   * Enable dynamically-sized payloads
-   *
-   * This way you don't always have to send large packets just to send them
-   * once in a while.  This enables dynamic payloads on ALL pipes.
-   *
-   * @see examples/pingpair_pl/pingpair_dyn.pde
-   */
-  void enableDynamicPayloads(void);
+/**
+ * Determine whether the hardware is an nRF24L01+ or not.
+ *
+ * @return TRUE if the hardware is nRF24L01+ (or compatible) and FALSE
+ * if its not.
+ */
+uint8_t nrf24_isPVariant(void) ;
 
-  /**
-   * Determine whether the hardware is an nRF24L01+ or not.
-   *
-   * @return true if the hardware is nRF24L01+ (or compatible) and false
-   * if its not.
-   */
-  bool isPVariant(void) ;
+/**
+ * Enable or disable auto-acknowlede packets
+ *
+ * This is enabled by default, so it's only needed if you want to turn
+ * it off for some reason.
+ *
+ * @param enable Whether to enable (TRUE) or disable (FALSE) auto-acks
+ */
+void nrf24_setAutoAck(uint8_t enable);
 
-  /**
-   * Enable or disable auto-acknowlede packets
-   *
-   * This is enabled by default, so it's only needed if you want to turn
-   * it off for some reason.
-   *
-   * @param enable Whether to enable (true) or disable (false) auto-acks
-   */
-  void setAutoAck(bool enable);
+/**
+ * Enable or disable auto-acknowlede packets on a per pipeline basis.
+ *
+ * AA is enabled by default, so it's only needed if you want to turn
+ * it off/on for some reason on a per pipeline basis.
+ *
+ * @param pipe Which pipeline to modify
+ * @param enable Whether to enable (TRUE) or disable (FALSE) auto-acks
+ */
+void nrf24_setAutoAck_pipe( uint8_t pipe, uint8_t enable ) ;
 
-  /**
-   * Enable or disable auto-acknowlede packets on a per pipeline basis.
-   *
-   * AA is enabled by default, so it's only needed if you want to turn
-   * it off/on for some reason on a per pipeline basis.
-   *
-   * @param pipe Which pipeline to modify
-   * @param enable Whether to enable (true) or disable (false) auto-acks
-   */
-  void setAutoAck( uint8_t pipe, bool enable ) ;
+/**
+ * Set Power Amplifier (PA) level to one of four levels.
+ * Relative mnemonics have been used to allow for future PA level
+ * changes. According to 6.5 of the nRF24L01+ specification sheet,
+ * they translate to: RF24_PA_MIN=-18dBm, RF24_PA_LOW=-12dBm,
+ * RF24_PA_MED=-6dBM, and RF24_PA_HIGH=0dBm.
+ *
+ * @param level Desired PA level.
+ */
+void nrf24_setPALevel( rf24_pa_dbm_e level ) ;
 
-  /**
-   * Set Power Amplifier (PA) level to one of four levels.
-   * Relative mnemonics have been used to allow for future PA level
-   * changes. According to 6.5 of the nRF24L01+ specification sheet,
-   * they translate to: RF24_PA_MIN=-18dBm, RF24_PA_LOW=-12dBm,
-   * RF24_PA_MED=-6dBM, and RF24_PA_HIGH=0dBm.
-   *
-   * @param level Desired PA level.
-   */
-  void setPALevel( rf24_pa_dbm_e level ) ;
+/**
+ * Fetches the current PA level.
+ *
+ * @return Returns a value from the rf24_pa_dbm_e enum describing
+ * the current PA setting. Please remember, all values represented
+ * by the enum mnemonics are negative dBm. See setPALevel for
+ * return value descriptions.
+ */
+rf24_pa_dbm_e nrf24_getPALevel( void ) ;
 
-  /**
-   * Fetches the current PA level.
-   *
-   * @return Returns a value from the rf24_pa_dbm_e enum describing
-   * the current PA setting. Please remember, all values represented
-   * by the enum mnemonics are negative dBm. See setPALevel for
-   * return value descriptions.
-   */
-  rf24_pa_dbm_e getPALevel( void ) ;
+/**
+ * Set the transmission data rate
+ *
+ * @warning setting RF24_250KBPS will fail for non-plus units
+ *
+ * @param speed RF24_250KBPS for 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS for 2Mbps
+ * @return TRUE if the change was successful
+ */
+uint8_t nrf24_setDataRate(rf24_datarate_e speed);
 
-  /**
-   * Set the transmission data rate
-   *
-   * @warning setting RF24_250KBPS will fail for non-plus units
-   *
-   * @param speed RF24_250KBPS for 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS for 2Mbps
-   * @return true if the change was successful
-   */
-  bool setDataRate(rf24_datarate_e speed);
-  
-  /**
-   * Fetches the transmission data rate
-   *
-   * @return Returns the hardware's currently configured datarate. The value
-   * is one of 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS, as defined in the
-   * rf24_datarate_e enum.
-   */
-  rf24_datarate_e getDataRate( void ) ;
+/**
+ * Fetches the transmission data rate
+ *
+ * @return Returns the hardware's currently configured datarate. The value
+ * is one of 250kbs, RF24_1MBPS for 1Mbps, or RF24_2MBPS, as defined in the
+ * rf24_datarate_e enum.
+ */
+rf24_datarate_e nrf24_getDataRate( void ) ;
 
-  /**
-   * Set the CRC length
-   *
-   * @param length RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
-   */
-  void setCRCLength(rf24_crclength_e length);
+/**
+ * Set the CRC length
+ *
+ * @param length RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
+ */
+void nrf24_setCRCLength(rf24_crclength_e length);
 
-  /**
-   * Get the CRC length
-   *
-   * @return RF24_DISABLED if disabled or RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
-   */
-  rf24_crclength_e getCRCLength(void);
+/**
+ * Get the CRC length
+ *
+ * @return RF24_DISABLED if disabled or RF24_CRC_8 for 8-bit or RF24_CRC_16 for 16-bit
+ */
+rf24_crclength_e nrf24_getCRCLength(void);
 
-  /**
-   * Disable CRC validation
-   *
-   */
-  void disableCRC( void ) ;
+/**
+ * Disable CRC validation
+ *
+ */
+void nrf24_disableCRC( void ) ;
 
-  /**@}*/
-  /**
-   * @name Advanced Operation 
-   *
-   *  Methods you can use to drive the chip in more advanced ways 
-   */
-  /**@{*/
+/**@}*/
+/**
+ * @name Advanced Operation 
+ *
+ *  Methods you can use to drive the chip in more advanced ways 
+ */
+/**@{*/
 
-  /**
-   * Print a giant block of debugging information to stdout
-   *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
-   */
-  void printDetails(void);
+/**
+ * Print a giant block of debugging information to stdout
+ *
+ * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+ */
+void nrf24_printDetails(void);
 
-  /**
-   * Enter low-power mode
-   *
-   * To return to normal power mode, either write() some data or
-   * startListening, or powerUp().
-   */
-  void powerDown(void);
+/**
+ * Enter low-power mode
+ *
+ * To return to normal power mode, either write() some data or
+ * startListening, or powerUp().
+ */
+void nrf24_powerDown(void);
 
-  /**
-   * Leave low-power mode - making radio more responsive
-   *
-   * To return to low power mode, call powerDown().
-   */
-  void powerUp(void) ;
+/**
+ * Leave low-power mode - making radio more responsive
+ *
+ * To return to low power mode, call powerDown().
+ */
+void nrf24_powerUp(void) ;
 
-  /**
-   * Test whether there are bytes available to be read
-   *
-   * Use this version to discover on which pipe the message
-   * arrived.
-   *
-   * @param[out] pipe_num Which pipe has the payload available
-   * @return True if there is a payload available, false if none is
-   */
-  bool available(uint8_t* pipe_num);
+/**
+ * Test whether there are bytes available to be read
+ *
+ * Use this version to discover on which pipe the message
+ * arrived.
+ *
+ * @param[out] pipe_num Which pipe has the payload available
+ * @return True if there is a payload available, FALSE if none is
+ */
+uint8_t nrf24_available_pipe(uint8_t* pipe_num);
 
-  /**
-   * Non-blocking write to the open writing pipe
-   *
-   * Just like write(), but it returns immediately. To find out what happened
-   * to the send, catch the IRQ and then call whatHappened().
-   *
-   * @see write()
-   * @see whatHappened()
-   *
-   * @param buf Pointer to the data to be sent
-   * @param len Number of bytes to be sent
-   * @return True if the payload was delivered successfully false if not
-   */
-  void startWrite( const void* buf, uint8_t len );
+/**
+ * Non-blocking write to the open writing pipe
+ *
+ * Just like write(), but it returns immediately. To find out what happened
+ * to the send, catch the IRQ and then call whatHappened().
+ *
+ * @see write()
+ * @see whatHappened()
+ *
+ * @param buf Pointer to the data to be sent
+ * @param len Number of bytes to be sent
+ * @return True if the payload was delivered successfully FALSE if not
+ */
+void nrf24_startWrite( const void* buf, uint8_t len );
 
-  /**
-   * Write an ack payload for the specified pipe
-   *
-   * The next time a message is received on @p pipe, the data in @p buf will
-   * be sent back in the acknowledgement.
-   *
-   * @warning According to the data sheet, only three of these can be pending
-   * at any time.  I have not tested this.
-   *
-   * @param pipe Which pipe# (typically 1-5) will get this response.
-   * @param buf Pointer to data that is sent
-   * @param len Length of the data to send, up to 32 bytes max.  Not affected
-   * by the static payload set by setPayloadSize().
-   */
-  void writeAckPayload(uint8_t pipe, const void* buf, uint8_t len);
+/**
+ * Write an ack payload for the specified pipe
+ *
+ * The next time a message is received on @p pipe, the data in @p buf will
+ * be sent back in the acknowledgement.
+ *
+ * @warning According to the data sheet, only three of these can be pending
+ * at any time.  I have not tested this.
+ *
+ * @param pipe Which pipe# (typically 1-5) will get this response.
+ * @param buf Pointer to data that is sent
+ * @param len Length of the data to send, up to 32 bytes max.  Not affected
+ * by the static payload set by setPayloadSize().
+ */
+void nrf24_writeAckPayload(uint8_t pipe, const void* buf, uint8_t len);
 
-  /**
-   * Determine if an ack payload was received in the most recent call to
-   * write().
-   *
-   * Call read() to retrieve the ack payload.
-   *
-   * @warning Calling this function clears the internal flag which indicates
-   * a payload is available.  If it returns true, you must read the packet
-   * out as the very next interaction with the radio, or the results are
-   * undefined.
-   *
-   * @return True if an ack payload is available.
-   */
-  bool isAckPayloadAvailable(void);
+/**
+ * Determine if an ack payload was received in the most recent call to
+ * write().
+ *
+ * Call read() to retrieve the ack payload.
+ *
+ * @warning Calling this function clears the internal flag which indicates
+ * a payload is available.  If it returns TRUE, you must read the packet
+ * out as the very next interaction with the radio, or the results are
+ * undefined.
+ *
+ * @return True if an ack payload is available.
+ */
+uint8_t nrf24_isAckPayloadAvailable(void);
 
-  /**
-   * Call this when you get an interrupt to find out why
-   *
-   * Tells you what caused the interrupt, and clears the state of
-   * interrupts.
-   *
-   * @param[out] tx_ok The send was successful (TX_DS)
-   * @param[out] tx_fail The send failed, too many retries (MAX_RT)
-   * @param[out] rx_ready There is a message waiting to be read (RX_DS)
-   */
-  void whatHappened(bool& tx_ok,bool& tx_fail,bool& rx_ready);
+/**
+ * Call this when you get an interrupt to find out why
+ *
+ * Tells you what caused the interrupt, and clears the state of
+ * interrupts.
+ *
+ * @param[out] tx_ok The send was successful (TX_DS)
+ * @param[out] tx_fail The send failed, too many retries (MAX_RT)
+ * @param[out] rx_ready There is a message waiting to be read (RX_DS)
+ */
+void nrf24_whatHappened(uint8_t tx_ok,uint8_t tx_fail,uint8_t rx_ready);
 
-  /**
-   * Test whether there was a carrier on the line for the
-   * previous listening period.
-   *
-   * Useful to check for interference on the current channel.
-   *
-   * @return true if was carrier, false if not
-   */
-  bool testCarrier(void);
+/**
+ * Test whether there was a carrier on the line for the
+ * previous listening period.
+ *
+ * Useful to check for interference on the current channel.
+ *
+ * @return TRUE if was carrier, FALSE if not
+ */
+uint8_t nrf24_testCarrier(void);
 
-  /**
-   * Test whether a signal (carrier or otherwise) greater than
-   * or equal to -64dBm is present on the channel. Valid only
-   * on nRF24L01P (+) hardware. On nRF24L01, use testCarrier().
-   *
-   * Useful to check for interference on the current channel and
-   * channel hopping strategies.
-   *
-   * @return true if signal => -64dBm, false if not
-   */
-  bool testRPD(void) ;
+/**
+ * Test whether a signal (carrier or otherwise) greater than
+ * or equal to -64dBm is present on the channel. Valid only
+ * on nRF24L01P (+) hardware. On nRF24L01, use testCarrier().
+ *
+ * Useful to check for interference on the current channel and
+ * channel hopping strategies.
+ *
+ * @return TRUE if signal => -64dBm, FALSE if not
+ */
+uint8_t nrf24_testRPD(void) ;
 
-  /**@}*/
-};
+/**@}*/
 
 /**
  * @example GettingStarted.pde

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -1,65 +1,24 @@
-
 /*
- Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+ Copyright (C) 2011,2012 J. Coliz <maniacbug@ymail.com>, jaseg <s@jaseg.de>
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
- version 2 as published by the Free Software Foundation.
+ version 3 as published by the Free Software Foundation.
  */
 
 #ifndef __RF24_CONFIG_H__
 #define __RF24_CONFIG_H__
 
-#if ARDUINO < 100
-#include <WProgram.h>
-#else
-#include <Arduino.h>
-#endif
+#define CE_PORT   PORTB
+#define CE_DDR    DDRB
+#define CE_PIN    0
 
-#include <stddef.h>
+#define CSN_PORT  PORTL
+#define CSN_DDR   DDRL
+#define CSN_PIN   0
 
-// Stuff that is normally provided by Arduino
-#ifdef ARDUINO
-#include <SPI.h>
-#else
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-extern HardwareSPI SPI;
-#define _BV(x) (1<<(x))
-#endif
+#define MAX_PAYLOAD_SIZE  32
 
-#undef SERIAL_DEBUG
-#ifdef SERIAL_DEBUG
-#define IF_SERIAL_DEBUG(x) ({x;})
-#else
-#define IF_SERIAL_DEBUG(x)
-#endif
-
-// Avoid spurious warnings
-#if 1
-#if ! defined( NATIVE ) && defined( ARDUINO )
-#undef PROGMEM
-#define PROGMEM __attribute__(( section(".progmem.data") ))
-#undef PSTR
-#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
-#endif
-#endif
-
-// Progmem is Arduino-specific
-#ifdef ARDUINO
-#include <avr/pgmspace.h>
-#define PRIPSTR "%S"
-#else
-typedef char const char;
-typedef uint16_t prog_uint16_t;
-#define PSTR(x) (x)
-#define printf_P printf
-#define strlen_P strlen
-#define PROGMEM
-#define pgm_read_word(p) (*(p)) 
-#define PRIPSTR "%s"
-#endif
+//typedef char const char;
 
 #endif // __RF24_CONFIG_H__
-// vim:ai:cin:sts=2 sw=2 ft=cpp

--- a/uart.c
+++ b/uart.c
@@ -1,0 +1,651 @@
+/*************************************************************************
+Title:    Interrupt UART library with receive/transmit circular buffers
+Author:   Peter Fleury <pfleury@gmx.ch>   http://jump.to/fleury
+File:     $Id: uart.c,v 1.6.2.2 2009/11/29 08:56:12 Peter Exp $
+Software: AVR-GCC 4.1, AVR Libc 1.4.6 or higher
+Hardware: any AVR with built-in UART, 
+License:  GNU General Public License 
+          
+DESCRIPTION:
+    An interrupt is generated when the UART has finished transmitting or
+    receiving a byte. The interrupt handling routines use circular buffers
+    for buffering received and transmitted data.
+    
+    The UART_RX_BUFFER_SIZE and UART_TX_BUFFER_SIZE variables define
+    the buffer size in bytes. Note that these variables must be a 
+    power of 2.
+    
+USAGE:
+    Refere to the header file uart.h for a description of the routines. 
+    See also example test_uart.c.
+
+NOTES:
+    Based on Atmel Application Note AVR306
+                    
+LICENSE:
+    Copyright (C) 2006 Peter Fleury
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+                        
+*************************************************************************/
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <avr/pgmspace.h>
+#include "uart.h"
+
+
+/*
+ *  constants and macros
+ */
+
+/* size of RX/TX buffers */
+#define UART_RX_BUFFER_MASK ( UART_RX_BUFFER_SIZE - 1)
+#define UART_TX_BUFFER_MASK ( UART_TX_BUFFER_SIZE - 1)
+
+#if ( UART_RX_BUFFER_SIZE & UART_RX_BUFFER_MASK )
+#error RX buffer size is not a power of 2
+#endif
+#if ( UART_TX_BUFFER_SIZE & UART_TX_BUFFER_MASK )
+#error TX buffer size is not a power of 2
+#endif
+
+#if defined(__AVR_AT90S2313__) \
+ || defined(__AVR_AT90S4414__) || defined(__AVR_AT90S4434__) \
+ || defined(__AVR_AT90S8515__) || defined(__AVR_AT90S8535__) \
+ || defined(__AVR_ATmega103__)
+ /* old AVR classic or ATmega103 with one UART */
+ #define AT90_UART
+ #define UART0_RECEIVE_INTERRUPT   SIG_UART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_UART_DATA
+ #define UART0_STATUS   USR
+ #define UART0_CONTROL  UCR
+ #define UART0_DATA     UDR  
+ #define UART0_UDRIE    UDRIE
+#elif defined(__AVR_AT90S2333__) || defined(__AVR_AT90S4433__)
+ /* old AVR classic with one UART */
+ #define AT90_UART
+ #define UART0_RECEIVE_INTERRUPT   SIG_UART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_UART_DATA
+ #define UART0_STATUS   UCSRA
+ #define UART0_CONTROL  UCSRB
+ #define UART0_DATA     UDR 
+ #define UART0_UDRIE    UDRIE
+#elif  defined(__AVR_ATmega8__)  || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__) \
+  || defined(__AVR_ATmega8515__) || defined(__AVR_ATmega8535__) \
+  || defined(__AVR_ATmega323__)
+  /* ATmega with one USART */
+ #define ATMEGA_USART
+ #define UART0_RECEIVE_INTERRUPT   SIG_UART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_UART_DATA
+ #define UART0_STATUS   UCSRA
+ #define UART0_CONTROL  UCSRB
+ #define UART0_DATA     UDR
+ #define UART0_UDRIE    UDRIE
+#elif defined(__AVR_ATmega163__) 
+  /* ATmega163 with one UART */
+ #define ATMEGA_UART
+ #define UART0_RECEIVE_INTERRUPT   SIG_UART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_UART_DATA
+ #define UART0_STATUS   UCSRA
+ #define UART0_CONTROL  UCSRB
+ #define UART0_DATA     UDR
+ #define UART0_UDRIE    UDRIE
+#elif defined(__AVR_ATmega162__) 
+ /* ATmega with two USART */
+ #define ATMEGA_USART0
+ #define ATMEGA_USART1
+ #define UART0_RECEIVE_INTERRUPT   SIG_USART0_RECV
+ #define UART1_RECEIVE_INTERRUPT   SIG_USART1_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_USART0_DATA
+ #define UART1_TRANSMIT_INTERRUPT  SIG_USART1_DATA
+ #define UART0_STATUS   UCSR0A
+ #define UART0_CONTROL  UCSR0B
+ #define UART0_DATA     UDR0
+ #define UART0_UDRIE    UDRIE0
+ #define UART1_STATUS   UCSR1A
+ #define UART1_CONTROL  UCSR1B
+ #define UART1_DATA     UDR1
+ #define UART1_UDRIE    UDRIE1
+#elif defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__) 
+ /* ATmega with two USART */
+ #define ATMEGA_USART0
+ #define ATMEGA_USART1
+ #define UART0_RECEIVE_INTERRUPT   SIG_UART0_RECV
+ #define UART1_RECEIVE_INTERRUPT   SIG_UART1_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_UART0_DATA
+ #define UART1_TRANSMIT_INTERRUPT  SIG_UART1_DATA
+ #define UART0_STATUS   UCSR0A
+ #define UART0_CONTROL  UCSR0B
+ #define UART0_DATA     UDR0
+ #define UART0_UDRIE    UDRIE0
+ #define UART1_STATUS   UCSR1A
+ #define UART1_CONTROL  UCSR1B
+ #define UART1_DATA     UDR1
+ #define UART1_UDRIE    UDRIE1
+#elif defined(__AVR_ATmega161__)
+ /* ATmega with UART */
+ #error "AVR ATmega161 currently not supported by this libaray !"
+#elif defined(__AVR_ATmega169__) 
+ /* ATmega with one USART */
+ #define ATMEGA_USART
+ #define UART0_RECEIVE_INTERRUPT   SIG_USART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_USART_DATA
+ #define UART0_STATUS   UCSRA
+ #define UART0_CONTROL  UCSRB
+ #define UART0_DATA     UDR
+ #define UART0_UDRIE    UDRIE
+#elif defined(__AVR_ATmega48__) ||defined(__AVR_ATmega88__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega48P__) || defined(__AVR_ATmega88P__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328P__)
+ /* ATmega with one USART */
+ #define ATMEGA_USART0
+ #define UART0_RECEIVE_INTERRUPT   USART_RX_vect
+ #define UART0_TRANSMIT_INTERRUPT  USART_TX_vect
+ #define UART0_STATUS   UCSR0A
+ #define UART0_CONTROL  UCSR0B
+ #define UART0_DATA     UDR0
+ #define UART0_UDRIE    UDRIE0
+#elif defined(__AVR_ATtiny2313__)
+ #define ATMEGA_USART
+ #define UART0_RECEIVE_INTERRUPT   SIG_USART0_RX 
+ #define UART0_TRANSMIT_INTERRUPT  SIG_USART0_UDRE
+ #define UART0_STATUS   UCSRA
+ #define UART0_CONTROL  UCSRB
+ #define UART0_DATA     UDR
+ #define UART0_UDRIE    UDRIE
+#elif defined(__AVR_ATmega329__) ||defined(__AVR_ATmega3290__) ||\
+      defined(__AVR_ATmega649__) ||defined(__AVR_ATmega6490__) ||\
+      defined(__AVR_ATmega325__) ||defined(__AVR_ATmega3250__) ||\
+      defined(__AVR_ATmega645__) ||defined(__AVR_ATmega6450__)
+  /* ATmega with one USART */
+  #define ATMEGA_USART0
+  #define UART0_RECEIVE_INTERRUPT   SIG_UART_RECV
+  #define UART0_TRANSMIT_INTERRUPT  SIG_UART_DATA
+  #define UART0_STATUS   UCSR0A
+  #define UART0_CONTROL  UCSR0B
+  #define UART0_DATA     UDR0
+  #define UART0_UDRIE    UDRIE0
+#elif defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) || defined(__AVR_ATmega1280__)  || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega640__)
+/* ATmega with two USART */
+  #define ATMEGA_USART0
+  #define ATMEGA_USART1
+  #define UART0_RECEIVE_INTERRUPT   SIG_USART0_RECV
+  #define UART1_RECEIVE_INTERRUPT   SIG_USART1_RECV
+  #define UART0_TRANSMIT_INTERRUPT  SIG_USART0_DATA
+  #define UART1_TRANSMIT_INTERRUPT  SIG_USART1_DATA
+  #define UART0_STATUS   UCSR0A
+  #define UART0_CONTROL  UCSR0B
+  #define UART0_DATA     UDR0
+  #define UART0_UDRIE    UDRIE0
+  #define UART1_STATUS   UCSR1A
+  #define UART1_CONTROL  UCSR1B
+  #define UART1_DATA     UDR1
+  #define UART1_UDRIE    UDRIE1  
+#elif defined(__AVR_ATmega644__)
+ /* ATmega with one USART */
+ #define ATMEGA_USART0
+ #define UART0_RECEIVE_INTERRUPT   SIG_USART_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_USART_DATA
+ #define UART0_STATUS   UCSR0A
+ #define UART0_CONTROL  UCSR0B
+ #define UART0_DATA     UDR0
+ #define UART0_UDRIE    UDRIE0
+#elif defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324P__) || defined(__AVR_ATmega644P__)
+ /* ATmega with two USART */
+ #define ATMEGA_USART0
+ #define ATMEGA_USART1
+ #define UART0_RECEIVE_INTERRUPT   SIG_USART_RECV
+ #define UART1_RECEIVE_INTERRUPT   SIG_USART1_RECV
+ #define UART0_TRANSMIT_INTERRUPT  SIG_USART_DATA
+ #define UART1_TRANSMIT_INTERRUPT  SIG_USART1_DATA
+ #define UART0_STATUS   UCSR0A
+ #define UART0_CONTROL  UCSR0B
+ #define UART0_DATA     UDR0
+ #define UART0_UDRIE    UDRIE0
+ #define UART1_STATUS   UCSR1A
+ #define UART1_CONTROL  UCSR1B
+ #define UART1_DATA     UDR1
+ #define UART1_UDRIE    UDRIE1
+#else
+ #error "no UART definition for MCU available"
+#endif
+
+
+/*
+ *  module global variables
+ */
+static volatile unsigned char UART_TxBuf[UART_TX_BUFFER_SIZE];
+static volatile unsigned char UART_RxBuf[UART_RX_BUFFER_SIZE];
+static volatile unsigned char UART_TxHead;
+static volatile unsigned char UART_TxTail;
+static volatile unsigned char UART_RxHead;
+static volatile unsigned char UART_RxTail;
+static volatile unsigned char UART_LastRxError;
+
+#if defined( ATMEGA_USART1 )
+static volatile unsigned char UART1_TxBuf[UART_TX_BUFFER_SIZE];
+static volatile unsigned char UART1_RxBuf[UART_RX_BUFFER_SIZE];
+static volatile unsigned char UART1_TxHead;
+static volatile unsigned char UART1_TxTail;
+static volatile unsigned char UART1_RxHead;
+static volatile unsigned char UART1_RxTail;
+static volatile unsigned char UART1_LastRxError;
+#endif
+
+
+
+ISR(UART0_RECEIVE_INTERRUPT)
+/*************************************************************************
+Function: UART Receive Complete interrupt
+Purpose:  called when the UART has received a character
+**************************************************************************/
+{
+    unsigned char tmphead;
+    unsigned char data;
+    unsigned char usr;
+    unsigned char lastRxError;
+ 
+ 
+    /* read UART status register and UART data register */ 
+    usr  = UART0_STATUS;
+    data = UART0_DATA;
+    
+    /* */
+#if defined( AT90_UART )
+    lastRxError = (usr & (_BV(FE)|_BV(DOR)) );
+#elif defined( ATMEGA_USART )
+    lastRxError = (usr & (_BV(FE)|_BV(DOR)) );
+#elif defined( ATMEGA_USART0 )
+    lastRxError = (usr & (_BV(FE0)|_BV(DOR0)) );
+#elif defined ( ATMEGA_UART )
+    lastRxError = (usr & (_BV(FE)|_BV(DOR)) );
+#endif
+        
+    /* calculate buffer index */ 
+    tmphead = ( UART_RxHead + 1) & UART_RX_BUFFER_MASK;
+    
+    if ( tmphead == UART_RxTail ) {
+        /* error: receive buffer overflow */
+        lastRxError = UART_BUFFER_OVERFLOW >> 8;
+    }else{
+        /* store new index */
+        UART_RxHead = tmphead;
+        /* store received data in buffer */
+        UART_RxBuf[tmphead] = data;
+    }
+    UART_LastRxError = lastRxError;   
+}
+
+
+ISR(UART0_TRANSMIT_INTERRUPT)
+/*************************************************************************
+Function: UART Data Register Empty interrupt
+Purpose:  called when the UART is ready to transmit the next byte
+**************************************************************************/
+{
+    unsigned char tmptail;
+
+    
+    if ( UART_TxHead != UART_TxTail) {
+        /* calculate and store new buffer index */
+        tmptail = (UART_TxTail + 1) & UART_TX_BUFFER_MASK;
+        UART_TxTail = tmptail;
+        /* get one byte from buffer and write it to UART */
+        UART0_DATA = UART_TxBuf[tmptail];  /* start transmission */
+    }else{
+        /* tx buffer empty, disable UDRE interrupt */
+        UART0_CONTROL &= ~_BV(UART0_UDRIE);
+    }
+}
+
+
+/*************************************************************************
+Function: uart_init()
+Purpose:  initialize UART and set baudrate
+Input:    baudrate using macro UART_BAUD_SELECT()
+Returns:  none
+**************************************************************************/
+void uart_init(unsigned int baudrate)
+{
+    UART_TxHead = 0;
+    UART_TxTail = 0;
+    UART_RxHead = 0;
+    UART_RxTail = 0;
+    
+#if defined( AT90_UART )
+    /* set baud rate */
+    UBRR = (unsigned char)baudrate; 
+
+    /* enable UART receiver and transmmitter and receive complete interrupt */
+    UART0_CONTROL = _BV(RXCIE)|_BV(RXEN)|_BV(TXEN);
+
+#elif defined (ATMEGA_USART)
+    /* Set baud rate */
+    if ( baudrate & 0x8000 )
+    {
+    	 UART0_STATUS = (1<<U2X);  //Enable 2x speed 
+    	 baudrate &= ~0x8000;
+    }
+    UBRRH = (unsigned char)(baudrate>>8);
+    UBRRL = (unsigned char) baudrate;
+   
+    /* Enable USART receiver and transmitter and receive complete interrupt */
+    UART0_CONTROL = _BV(RXCIE)|(1<<RXEN)|(1<<TXEN);
+    
+    /* Set frame format: asynchronous, 8data, no parity, 1stop bit */
+    #ifdef URSEL
+    UCSRC = (1<<URSEL)|(3<<UCSZ0);
+    #else
+    UCSRC = (3<<UCSZ0);
+    #endif 
+    
+#elif defined (ATMEGA_USART0 )
+    /* Set baud rate */
+    if ( baudrate & 0x8000 ) 
+    {
+   		UART0_STATUS = (1<<U2X0);  //Enable 2x speed 
+   		baudrate &= ~0x8000;
+   	}
+    UBRR0H = (unsigned char)(baudrate>>8);
+    UBRR0L = (unsigned char) baudrate;
+
+    /* Enable USART receiver and transmitter and receive complete interrupt */
+    UART0_CONTROL = _BV(RXCIE0)|(1<<RXEN0)|(1<<TXEN0);
+    
+    /* Set frame format: asynchronous, 8data, no parity, 1stop bit */
+    #ifdef URSEL0
+    UCSR0C = (1<<URSEL0)|(3<<UCSZ00);
+    #else
+    UCSR0C = (3<<UCSZ00);
+    #endif 
+
+#elif defined ( ATMEGA_UART )
+    /* set baud rate */
+    if ( baudrate & 0x8000 ) 
+    {
+    	UART0_STATUS = (1<<U2X);  //Enable 2x speed 
+    	baudrate &= ~0x8000;
+    }
+    UBRRHI = (unsigned char)(baudrate>>8);
+    UBRR   = (unsigned char) baudrate;
+
+    /* Enable UART receiver and transmitter and receive complete interrupt */
+    UART0_CONTROL = _BV(RXCIE)|(1<<RXEN)|(1<<TXEN);
+
+#endif
+
+}/* uart_init */
+
+
+/*************************************************************************
+Function: uart_getc()
+Purpose:  return byte from ringbuffer  
+Returns:  lower byte:  received byte from ringbuffer
+          higher byte: last receive error
+**************************************************************************/
+unsigned int uart_getc(void)
+{    
+    unsigned char tmptail;
+    unsigned char data;
+
+
+    if ( UART_RxHead == UART_RxTail ) {
+        return UART_NO_DATA;   /* no data available */
+    }
+    
+    /* calculate /store buffer index */
+    tmptail = (UART_RxTail + 1) & UART_RX_BUFFER_MASK;
+    UART_RxTail = tmptail; 
+    
+    /* get data from receive buffer */
+    data = UART_RxBuf[tmptail];
+    
+    return (UART_LastRxError << 8) + data;
+
+}/* uart_getc */
+
+
+/*************************************************************************
+Function: uart_putc()
+Purpose:  write byte to ringbuffer for transmitting via UART
+Input:    byte to be transmitted
+Returns:  none          
+**************************************************************************/
+void uart_putc(unsigned char data)
+{
+    unsigned char tmphead;
+
+    
+    tmphead  = (UART_TxHead + 1) & UART_TX_BUFFER_MASK;
+    
+    while ( tmphead == UART_TxTail ){
+        ;/* wait for free space in buffer */
+    }
+    
+    UART_TxBuf[tmphead] = data;
+    UART_TxHead = tmphead;
+
+    /* enable UDRE interrupt */
+    UART0_CONTROL    |= _BV(UART0_UDRIE);
+
+}/* uart_putc */
+
+
+/*************************************************************************
+Function: uart_puts()
+Purpose:  transmit string to UART
+Input:    string to be transmitted
+Returns:  none          
+**************************************************************************/
+void uart_puts(const char *s )
+{
+    while (*s) 
+      uart_putc(*s++);
+
+}/* uart_puts */
+
+
+/*************************************************************************
+Function: uart_puts_p()
+Purpose:  transmit string from program memory to UART
+Input:    program memory string to be transmitted
+Returns:  none
+**************************************************************************/
+void uart_puts_p(const char *progmem_s )
+{
+    register char c;
+    
+    while ( (c = pgm_read_byte(progmem_s++)) ) 
+      uart_putc(c);
+
+}/* uart_puts_p */
+
+
+/*
+ * these functions are only for ATmegas with two USART
+ */
+#if defined( ATMEGA_USART1 )
+
+ISR(UART1_RECEIVE_INTERRUPT)
+/*************************************************************************
+Function: UART1 Receive Complete interrupt
+Purpose:  called when the UART1 has received a character
+**************************************************************************/
+{
+    unsigned char tmphead;
+    unsigned char data;
+    unsigned char usr;
+    unsigned char lastRxError;
+ 
+ 
+    /* read UART status register and UART data register */ 
+    usr  = UART1_STATUS;
+    data = UART1_DATA;
+    
+    /* */
+    lastRxError = (usr & (_BV(FE1)|_BV(DOR1)) );
+        
+    /* calculate buffer index */ 
+    tmphead = ( UART1_RxHead + 1) & UART_RX_BUFFER_MASK;
+    
+    if ( tmphead == UART1_RxTail ) {
+        /* error: receive buffer overflow */
+        lastRxError = UART_BUFFER_OVERFLOW >> 8;
+    }else{
+        /* store new index */
+        UART1_RxHead = tmphead;
+        /* store received data in buffer */
+        UART1_RxBuf[tmphead] = data;
+    }
+    UART1_LastRxError = lastRxError;   
+}
+
+
+ISR(UART1_TRANSMIT_INTERRUPT)
+/*************************************************************************
+Function: UART1 Data Register Empty interrupt
+Purpose:  called when the UART1 is ready to transmit the next byte
+**************************************************************************/
+{
+    unsigned char tmptail;
+
+    
+    if ( UART1_TxHead != UART1_TxTail) {
+        /* calculate and store new buffer index */
+        tmptail = (UART1_TxTail + 1) & UART_TX_BUFFER_MASK;
+        UART1_TxTail = tmptail;
+        /* get one byte from buffer and write it to UART */
+        UART1_DATA = UART1_TxBuf[tmptail];  /* start transmission */
+    }else{
+        /* tx buffer empty, disable UDRE interrupt */
+        UART1_CONTROL &= ~_BV(UART1_UDRIE);
+    }
+}
+
+
+/*************************************************************************
+Function: uart1_init()
+Purpose:  initialize UART1 and set baudrate
+Input:    baudrate using macro UART_BAUD_SELECT()
+Returns:  none
+**************************************************************************/
+void uart1_init(unsigned int baudrate)
+{
+    UART1_TxHead = 0;
+    UART1_TxTail = 0;
+    UART1_RxHead = 0;
+    UART1_RxTail = 0;
+    
+
+    /* Set baud rate */
+    if ( baudrate & 0x8000 ) 
+    {
+    	UART1_STATUS = (1<<U2X1);  //Enable 2x speed 
+      baudrate &= ~0x8000;
+    }
+    UBRR1H = (unsigned char)(baudrate>>8);
+    UBRR1L = (unsigned char) baudrate;
+
+    /* Enable USART receiver and transmitter and receive complete interrupt */
+    UART1_CONTROL = _BV(RXCIE1)|(1<<RXEN1)|(1<<TXEN1);
+    
+    /* Set frame format: asynchronous, 8data, no parity, 1stop bit */   
+    #ifdef URSEL1
+    UCSR1C = (1<<URSEL1)|(3<<UCSZ10);
+    #else
+    UCSR1C = (3<<UCSZ10);
+    #endif 
+}/* uart_init */
+
+
+/*************************************************************************
+Function: uart1_getc()
+Purpose:  return byte from ringbuffer  
+Returns:  lower byte:  received byte from ringbuffer
+          higher byte: last receive error
+**************************************************************************/
+unsigned int uart1_getc(void)
+{    
+    unsigned char tmptail;
+    unsigned char data;
+
+
+    if ( UART1_RxHead == UART1_RxTail ) {
+        return UART_NO_DATA;   /* no data available */
+    }
+    
+    /* calculate /store buffer index */
+    tmptail = (UART1_RxTail + 1) & UART_RX_BUFFER_MASK;
+    UART1_RxTail = tmptail; 
+    
+    /* get data from receive buffer */
+    data = UART1_RxBuf[tmptail];
+    
+    return (UART1_LastRxError << 8) + data;
+
+}/* uart1_getc */
+
+
+/*************************************************************************
+Function: uart1_putc()
+Purpose:  write byte to ringbuffer for transmitting via UART
+Input:    byte to be transmitted
+Returns:  none          
+**************************************************************************/
+void uart1_putc(unsigned char data)
+{
+    unsigned char tmphead;
+
+    
+    tmphead  = (UART1_TxHead + 1) & UART_TX_BUFFER_MASK;
+    
+    while ( tmphead == UART1_TxTail ){
+        ;/* wait for free space in buffer */
+    }
+    
+    UART1_TxBuf[tmphead] = data;
+    UART1_TxHead = tmphead;
+
+    /* enable UDRE interrupt */
+    UART1_CONTROL    |= _BV(UART1_UDRIE);
+
+}/* uart1_putc */
+
+
+/*************************************************************************
+Function: uart1_puts()
+Purpose:  transmit string to UART1
+Input:    string to be transmitted
+Returns:  none          
+**************************************************************************/
+void uart1_puts(const char *s )
+{
+    while (*s) 
+      uart1_putc(*s++);
+
+}/* uart1_puts */
+
+
+/*************************************************************************
+Function: uart1_puts_p()
+Purpose:  transmit string from program memory to UART1
+Input:    program memory string to be transmitted
+Returns:  none
+**************************************************************************/
+void uart1_puts_p(const char *progmem_s )
+{
+    register char c;
+    
+    while ( (c = pgm_read_byte(progmem_s++)) ) 
+      uart1_putc(c);
+
+}/* uart1_puts_p */
+
+
+#endif

--- a/uart.h
+++ b/uart.h
@@ -1,0 +1,194 @@
+#ifndef UART_H
+#define UART_H
+/************************************************************************
+Title:    Interrupt UART library with receive/transmit circular buffers
+Author:   Peter Fleury <pfleury@gmx.ch>   http://jump.to/fleury
+File:     $Id: uart.h,v 1.8.2.1 2007/07/01 11:14:38 peter Exp $
+Software: AVR-GCC 4.1, AVR Libc 1.4
+Hardware: any AVR with built-in UART, tested on AT90S8515 & ATmega8 at 4 Mhz
+License:  GNU General Public License 
+Usage:    see Doxygen manual
+
+LICENSE:
+    Copyright (C) 2006 Peter Fleury
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    
+************************************************************************/
+
+/** 
+ *  @defgroup pfleury_uart UART Library
+ *  @code #include <uart.h> @endcode
+ * 
+ *  @brief Interrupt UART library using the built-in UART with transmit and receive circular buffers. 
+ *
+ *  This library can be used to transmit and receive data through the built in UART. 
+ *
+ *  An interrupt is generated when the UART has finished transmitting or
+ *  receiving a byte. The interrupt handling routines use circular buffers
+ *  for buffering received and transmitted data.
+ *
+ *  The UART_RX_BUFFER_SIZE and UART_TX_BUFFER_SIZE constants define
+ *  the size of the circular buffers in bytes. Note that these constants must be a power of 2.
+ *  You may need to adapt this constants to your target and your application by adding 
+ *  CDEFS += -DUART_RX_BUFFER_SIZE=nn -DUART_RX_BUFFER_SIZE=nn to your Makefile.
+ *
+ *  @note Based on Atmel Application Note AVR306
+ *  @author Peter Fleury pfleury@gmx.ch  http://jump.to/fleury
+ */
+ 
+/**@{*/
+
+
+#if (__GNUC__ * 100 + __GNUC_MINOR__) < 304
+#error "This library requires AVR-GCC 3.4 or later, update to newer AVR-GCC compiler !"
+#endif
+
+
+/*
+** constants and macros
+*/
+
+/** @brief  UART Baudrate Expression
+ *  @param  xtalcpu  system clock in Mhz, e.g. 4000000L for 4Mhz          
+ *  @param  baudrate baudrate in bps, e.g. 1200, 2400, 9600     
+ */
+#define UART_BAUD_SELECT(baudRate,xtalCpu) ((xtalCpu)/((baudRate)*16l)-1)
+
+/** @brief  UART Baudrate Expression for ATmega double speed mode
+ *  @param  xtalcpu  system clock in Mhz, e.g. 4000000L for 4Mhz           
+ *  @param  baudrate baudrate in bps, e.g. 1200, 2400, 9600     
+ */
+#define UART_BAUD_SELECT_DOUBLE_SPEED(baudRate,xtalCpu) (((xtalCpu)/((baudRate)*8l)-1)|0x8000)
+
+
+/** Size of the circular receive buffer, must be power of 2 */
+#ifndef UART_RX_BUFFER_SIZE
+#define UART_RX_BUFFER_SIZE 32
+#endif
+/** Size of the circular transmit buffer, must be power of 2 */
+#ifndef UART_TX_BUFFER_SIZE
+#define UART_TX_BUFFER_SIZE 32
+#endif
+
+/* test if the size of the circular buffers fits into SRAM */
+#if ( (UART_RX_BUFFER_SIZE+UART_TX_BUFFER_SIZE) >= (RAMEND-0x60 ) )
+#error "size of UART_RX_BUFFER_SIZE + UART_TX_BUFFER_SIZE larger than size of SRAM"
+#endif
+
+/* 
+** high byte error return code of uart_getc()
+*/
+#define UART_FRAME_ERROR      0x0800              /* Framing Error by UART       */
+#define UART_OVERRUN_ERROR    0x0400              /* Overrun condition by UART   */
+#define UART_BUFFER_OVERFLOW  0x0200              /* receive ringbuffer overflow */
+#define UART_NO_DATA          0x0100              /* no receive data available   */
+
+
+/*
+** function prototypes
+*/
+
+/**
+   @brief   Initialize UART and set baudrate 
+   @param   baudrate Specify baudrate using macro UART_BAUD_SELECT()
+   @return  none
+*/
+extern void uart_init(unsigned int baudrate);
+
+
+/**
+ *  @brief   Get received byte from ringbuffer
+ *
+ * Returns in the lower byte the received character and in the 
+ * higher byte the last receive error.
+ * UART_NO_DATA is returned when no data is available.
+ *
+ *  @param   void
+ *  @return  lower byte:  received byte from ringbuffer
+ *  @return  higher byte: last receive status
+ *           - \b 0 successfully received data from UART
+ *           - \b UART_NO_DATA           
+ *             <br>no receive data available
+ *           - \b UART_BUFFER_OVERFLOW   
+ *             <br>Receive ringbuffer overflow.
+ *             We are not reading the receive buffer fast enough, 
+ *             one or more received character have been dropped 
+ *           - \b UART_OVERRUN_ERROR     
+ *             <br>Overrun condition by UART.
+ *             A character already present in the UART UDR register was 
+ *             not read by the interrupt handler before the next character arrived,
+ *             one or more received characters have been dropped.
+ *           - \b UART_FRAME_ERROR       
+ *             <br>Framing Error by UART
+ */
+extern unsigned int uart_getc(void);
+
+
+/**
+ *  @brief   Put byte to ringbuffer for transmitting via UART
+ *  @param   data byte to be transmitted
+ *  @return  none
+ */
+extern void uart_putc(unsigned char data);
+
+
+/**
+ *  @brief   Put string to ringbuffer for transmitting via UART
+ *
+ *  The string is buffered by the uart library in a circular buffer
+ *  and one character at a time is transmitted to the UART using interrupts.
+ *  Blocks if it can not write the whole string into the circular buffer.
+ * 
+ *  @param   s string to be transmitted
+ *  @return  none
+ */
+extern void uart_puts(const char *s );
+
+
+/**
+ * @brief    Put string from program memory to ringbuffer for transmitting via UART.
+ *
+ * The string is buffered by the uart library in a circular buffer
+ * and one character at a time is transmitted to the UART using interrupts.
+ * Blocks if it can not write the whole string into the circular buffer.
+ *
+ * @param    s program memory string to be transmitted
+ * @return   none
+ * @see      uart_puts_P
+ */
+extern void uart_puts_p(const char *s );
+
+/**
+ * @brief    Macro to automatically put a string constant into program memory
+ */
+#define uart_puts_P(__s)       uart_puts_p(PSTR(__s))
+
+
+
+/** @brief  Initialize USART1 (only available on selected ATmegas) @see uart_init */
+extern void uart1_init(unsigned int baudrate);
+/** @brief  Get received byte of USART1 from ringbuffer. (only available on selected ATmega) @see uart_getc */
+extern unsigned int uart1_getc(void);
+/** @brief  Put byte to ringbuffer for transmitting via USART1 (only available on selected ATmega) @see uart_putc */
+extern void uart1_putc(unsigned char data);
+/** @brief  Put string to ringbuffer for transmitting via USART1 (only available on selected ATmega) @see uart_puts */
+extern void uart1_puts(const char *s );
+/** @brief  Put string from program memory to ringbuffer for transmitting via USART1 (only available on selected ATmega) @see uart_puts_p */
+extern void uart1_puts_p(const char *s );
+/** @brief  Macro to automatically put a string constant into program memory */
+#define uart1_puts_P(__s)       uart1_puts_p(PSTR(__s))
+
+/**@}*/
+
+
+#endif // UART_H 
+

--- a/util.c
+++ b/util.c
@@ -1,0 +1,62 @@
+/*
+ Copyright (C) 2012 jaseg <s@jaseg.de>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 3 as published by the Free Software Foundation.
+ */
+
+#include "util.h"
+#include "uart.h"
+
+void uart_puthex_nibble(uint8_t nibble){
+    if(nibble < 0xA)
+        uart_putc('0'+nibble);
+    else
+        uart_putc('A'+nibble-0xA);
+}
+
+void uart_puthex(uint8_t data){
+    uart_puthex_nibble(data>4);
+    uart_puthex_nibble(data&0xF);
+}
+
+void uart_puthex_16(uint16_t data){
+    uart_puthex(data>>8);
+    uart_puthex(data&0xFF);
+}
+
+void uart_puthex_flip_16(uint16_t data){
+    uart_puthex(data&0xFF);
+    uart_puthex(data>>8);
+}
+
+void uart_puthex_32(uint32_t data){
+    uint16_t high = data>>16;
+    uart_puthex_16(high);
+    uint16_t low = data&0xFFFF;
+    uart_puthex_16(low);
+}
+
+void uart_puthex_flip_32(uint32_t data){
+    uint16_t low = data&0xFFFF;
+    uart_puthex_flip_16(low);
+    uint16_t high = data>>16;
+    uart_puthex_flip_16(high);
+}
+
+void uart_putdec(uint8_t data){
+    if(data >= 100){
+        if(data >= 200){
+            uart_putc('2');
+            data -= 200;
+        }else{
+            uart_putc('1');
+            data -= 100;
+        }
+    }
+    uint8_t d2 = data/10;
+    data %= 10;
+    uart_putc('0'+d2);
+    uart_putc('0'+data);
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,24 @@
+/*
+ Copyright (C) 2012 jaseg <s@jaseg.de>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 3 as published by the Free Software Foundation.
+ */
+
+#ifndef __UTIL_H__
+#define __UTIL_H__
+#include <avr/io.h>
+
+void uart_puthex_nibble(uint8_t nibble);
+void uart_puthex(uint8_t data);
+void uart_puthex_16(uint16_t data);
+void uart_puthex_32(uint32_t data);
+void uart_puthex_flip_16(uint16_t data);
+void uart_puthex_flip_32(uint32_t data);
+void uart_putdec(uint8_t data);
+inline uint8_t min(uint8_t a, uint8_t b){
+    return a>b?b:a;
+}
+
+#endif//__UTIL_H__


### PR DESCRIPTION
Hey,
I just ported the driver to plain C without arduino dependencies (only avr-libc) for a project I'm working on where I do not use arduino. I also removed any printf references because I really do not like printf on AVRs ;)
Upside: It should be smaller and faster.
Downside: It is probably not arduino-compatible anymore, and it now needs a existing uart library. Also, it is not able anymore to control more than one chip (though that would be an easy fix).
Perhaps pull this into a separate branch and put a reference in the project description.
thx for the great project!
