### PR TITLE
Updated led_remote example to use correct var on line 172

### DIFF
--- a/examples/led_remote/led_remote.pde
+++ b/examples/led_remote/led_remote.pde
@@ -169,7 +169,7 @@ void setup(void)
     int i = num_led_pins;
     while(i--)
     {
-      pinMode(button_pins[i],OUTPUT);
+      pinMode(led_pins[i],OUTPUT);
       led_states[i] = HIGH;
       digitalWrite(led_pins[i],led_states[i]);
     }


### PR DESCRIPTION
Line 172 was using button_pins instead of led_pins.  This caused leds to be lit dim when set to HIGH.  Changed to correct var.
