### PR TITLE
Remove powerDown() from write command.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -494,9 +494,6 @@ bool RF24::write( const void* buf, uint8_t len )
 
   // Yay, we are done.
 
-  // Power down
-  powerDown();
-
   // Flush buffers (Is this a relic of past experimentation, and not needed anymore??)
   flush_tx();
 


### PR DESCRIPTION
Hi Maniacbug,

Thanks for your great job ! It's very useful for me.

I have some compatibility problem with Olimex MOD-24LR board and RF24 lib so i have to change the code.

Commit detail: 

Remove powerDown() from write command. Now, we can use Power On/Off from user application. Necessary because XTAL startup time is not the same for every NRF board.PowerUp can take more than 1 ms (see 6.1.7 "Tpd2stdby" in nRF24L01+ product specification). For my test on Olimex MOD-24LR module delayMicroseconds(150) after PowerUp on startWrite is too short and write don't work. It's difficult to have an optimized value for every case. So, it's probably better to do this on user app.

Have a nice day,
Loic Lefebvre
