### PR TITLE
Correct power-on delay

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -507,8 +507,10 @@ bool RF24::write( const void* buf, uint8_t len )
 void RF24::startWrite( const void* buf, uint8_t len )
 {
   // Transmitter power-up
-  write_register(CONFIG, ( read_register(CONFIG) | _BV(PWR_UP) ) & ~_BV(PRIM_RX) );
-  delayMicroseconds(150);
+  uint8_t old_config = read_register(CONFIG);
+  write_register(CONFIG, ( old_config | _BV(PWR_UP) ) & ~_BV(PRIM_RX) );
+  if ((old_config & _BV(PWR_UP)) == 0)
+    delayMicroseconds(1500);
 
   // Send the payload
   write_payload( buf, len );


### PR DESCRIPTION
The nRF24L01 datasheet documents the power-up startup time (from Power Down to Standby-I) as 1.5ms (1500us).  However startWrite only waits 150ms.  Increase this delay to the required value.

If the device is already powered up we can skip this delay entirely.

On some tests we get lucky - typically if we are switching from receive to transmit mode, so the oscillator is already warmed up.

However e.g. pingpair_pl the TX device is spends most of its time powered down.  The cold-start time on my module means with the 150us delay transmission fails most (>95%) of the time.
