### PR TITLE
add method to change hardware address size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ Please refer to:
 This chip uses the SPI bus, plus two chip control pins.  Remember that pin 10 must still remain an output, or
 the SPI hardware will go into 'slave' mode.
 
+### Some notes about the SI24R01 "power enhanced version 2.4G wireless module"
+
+The SI24R01 chip on these modules is apparently a Chinese clone of the NRF24L01+. Sometimes, when you buy an nRF24L01+ module (particularly on eBay), you will actually get an SI24R01 module instead. Below is some slightly cleaned up information found about this chip on a [Chinese reseller site](http://www.wayengineer.com/index.php?main_page=product_info&products_id=3442).
+
+> SI24R01 and NRF24L01 are completely compatible (SPI register, definition timing, the state diagram), which can communicate with each other, support NRF24L01+ all communication functions.
+
+> 1: 7dBm output power
+> SI24R1 default mode output power is 2~3dBm, if you want to output 7dBm, the register address 0x06 (RF_SETUP) the lowest register write 1 (NRF24L01+ without the use of the bit, the default is 0), namely 0x06 register a minimum of four to 1111
+
+Translation: you can actually broadcast at up to 7dBm with this module if you set bit 0 in RF_SETUP to 1. For the nRF24L01+, this bit is marked as obsolete/don't care, so it shouldn't hurt to set it.
+
+> 2: SI24R1 emission problem
+> Launch operation mode of SI24R1 and NRF24L01+ exactly the same, cause problems: if the register is powerdown mode operation, higher CE to at least 2ms, because the powerdown model of crystal does not work, crystal is from close to emission data need about 2ms. If the standbyI mode to drop-down CE high, that is not problem, CE only needs a pulse of 10us, because under the mode of standbyI crystal is the work (current is very small, only dozen microamperes)
+
+Translation: the transition from power-down to standby-I mode will take longer at about 2 ms on these modules, as opposed to 1.5 ms on the nRF24L01+.

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ Please refer to:
 This chip uses the SPI bus, plus two chip control pins.  Remember that pin 10 must still remain an output, or
 the SPI hardware will go into 'slave' mode.
 
-# Some notes about the SI24R01 "power enhanced version 2.4G wireless module"
+### Some notes about the SI24R01 "power enhanced version 2.4G wireless module"
 
 The SI24R01 chip on these modules is apparently a Chinese clone of the NRF24L01+. Sometimes, when you buy an nRF24L01+ module (particularly on eBay), you will actually get an SI24R01 module instead. Below is some slightly cleaned up information found about this chip on a [Chinese reseller site](http://www.wayengineer.com/index.php?main_page=product_info&products_id=3442).
 
-SI24R01 and NRF24L01 are completely compatible (SPI register, definition timing, the state diagram), which can communicate with each other, support NRF24L01+ all communication functions.
+> SI24R01 and NRF24L01 are completely compatible (SPI register, definition timing, the state diagram), which can communicate with each other, support NRF24L01+ all communication functions.
 
-1: 7dBm output power
-SI24R1 default mode output power is 2~3dBm, if you want to output 7dBm, the register address 0x06 (RF_SETUP) the lowest register write 1 (NRF24L01+ without the use of the bit, the default is 0), namely 0x06 register a minimum of four to 1111
+> 1: 7dBm output power
+> SI24R1 default mode output power is 2~3dBm, if you want to output 7dBm, the register address 0x06 (RF_SETUP) the lowest register write 1 (NRF24L01+ without the use of the bit, the default is 0), namely 0x06 register a minimum of four to 1111
 
 Translation: you can actually broadcast at up to 7dBm with this module if you set bit 0 in RF_SETUP to 1. For the nRF24L01+, this bit is marked as obsolete/don't care, so it shouldn't hurt to set it.
 
-2: SI24R1 emission problem
-Launch operation mode of SI24R1 and NRF24L01+ exactly the same, cause problems: if the register is powerdown mode operation, higher CE to at least 2ms, because the powerdown model of crystal does not work, crystal is from close to emission data need about 2ms. If the standbyI mode to drop-down CE high, that is not problem, CE only needs a pulse of 10us, because under the mode of standbyI crystal is the work (current is very small, only dozen microamperes)
+> 2: SI24R1 emission problem
+> Launch operation mode of SI24R1 and NRF24L01+ exactly the same, cause problems: if the register is powerdown mode operation, higher CE to at least 2ms, because the powerdown model of crystal does not work, crystal is from close to emission data need about 2ms. If the standbyI mode to drop-down CE high, that is not problem, CE only needs a pulse of 10us, because under the mode of standbyI crystal is the work (current is very small, only dozen microamperes)
 
 Translation: the transition from power-down to standby-I mode will take longer at about 2 ms on these modules, as opposed to 1.5 ms on the nRF24L01+.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ Please refer to:
 This chip uses the SPI bus, plus two chip control pins.  Remember that pin 10 must still remain an output, or
 the SPI hardware will go into 'slave' mode.
 
+# Some notes about the SI24R01 "power enhanced version 2.4G wireless module"
+
+The SI24R01 chip on these modules is apparently a Chinese clone of the NRF24L01+. Sometimes, when you buy an nRF24L01+ module (particularly on eBay), you will actually get an SI24R01 module instead. Below is some slightly cleaned up information found about this chip on a [Chinese reseller site](http://www.wayengineer.com/index.php?main_page=product_info&products_id=3442).
+
+SI24R01 and NRF24L01 are completely compatible (SPI register, definition timing, the state diagram), which can communicate with each other, support NRF24L01+ all communication functions.
+
+1: 7dBm output power
+SI24R1 default mode output power is 2~3dBm, if you want to output 7dBm, the register address 0x06 (RF_SETUP) the lowest register write 1 (NRF24L01+ without the use of the bit, the default is 0), namely 0x06 register a minimum of four to 1111
+
+Translation: you can actually broadcast at up to 7dBm with this module if you set bit 0 in RF_SETUP to 1. For the nRF24L01+, this bit is marked as obsolete/don't care, so it shouldn't hurt to set it.
+
+2: SI24R1 emission problem
+Launch operation mode of SI24R1 and NRF24L01+ exactly the same, cause problems: if the register is powerdown mode operation, higher CE to at least 2ms, because the powerdown model of crystal does not work, crystal is from close to emission data need about 2ms. If the standbyI mode to drop-down CE high, that is not problem, CE only needs a pulse of 10us, because under the mode of standbyI crystal is the work (current is very small, only dozen microamperes)
+
+Translation: the transition from power-down to standby-I mode will take longer at about 2 ms on these modules, as opposed to 1.5 ms on the nRF24L01+.

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -266,6 +266,14 @@ void RF24::setPayloadSize(uint8_t size)
 
 /****************************************************************************/
 
+void RF24::setAddressSize(uint8_t size)
+{
+  uint8_t tmp = max(3,min(5,size));
+  write_register(SETUP_AW, (tmp-2) & 0x03 );
+}
+
+/****************************************************************************/
+
 uint8_t RF24::getPayloadSize(void)
 {
   return payload_size;

--- a/RF24.h
+++ b/RF24.h
@@ -50,6 +50,7 @@ private:
   bool wide_band; /* 2Mbs data rate in use? */
   bool p_variant; /* False for RF24L01 and true for RF24L01P */
   uint8_t payload_size; /**< Fixed size of payloads */
+  uint8_t address_size; /**< Size of hardware addresses */
   bool ack_payload_available; /**< Whether there is an ack payload waiting */
   bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */ 
   uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */

--- a/RF24.h
+++ b/RF24.h
@@ -389,6 +389,15 @@ public:
   void setPayloadSize(uint8_t size);
 
   /**
+   * Set Hardware Address Size
+   *
+   * Set to either 3, 4 or 5 bytes. Default is 5.
+   *
+   * @param size The number of bytes in the payload
+   */
+  void setAddressSize(uint8_t size);
+
+  /**
    * Get Static Payload Size
    *
    * @see setPayloadSize()


### PR DESCRIPTION
For compatibility with other applications, it can be useful to set a lower hardware address size (nRF24L01(+) supports 3,4 or 5 bytes).
