### PR TITLE
add method to change hardware address size

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -266,6 +266,14 @@ void RF24::setPayloadSize(uint8_t size)
 
 /****************************************************************************/
 
+void RF24::setAddressSize(uint8_t size)
+{
+  uint8_t tmp = max(3,min(5,size));
+  write_register(SETUP_AW, (tmp-2) & 0x03 );
+}
+
+/****************************************************************************/
+
 uint8_t RF24::getPayloadSize(void)
 {
   return payload_size;

--- a/RF24.h
+++ b/RF24.h
@@ -50,6 +50,7 @@ private:
   bool wide_band; /* 2Mbs data rate in use? */
   bool p_variant; /* False for RF24L01 and true for RF24L01P */
   uint8_t payload_size; /**< Fixed size of payloads */
+  uint8_t address_size; /**< Size of hardware addresses */
   bool ack_payload_available; /**< Whether there is an ack payload waiting */
   bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */ 
   uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */

--- a/RF24.h
+++ b/RF24.h
@@ -389,6 +389,15 @@ public:
   void setPayloadSize(uint8_t size);
 
   /**
+   * Set Hardware Address Size
+   *
+   * Set to either 3, 4 or 5 bytes. Default is 5.
+   *
+   * @param size The number of bytes in the payload
+   */
+  void setAddressSize(uint8_t size);
+
+  /**
    * Get Static Payload Size
    *
    * @see setPayloadSize()


### PR DESCRIPTION
For compatibility with other applications, it can be useful to set a lower hardware address size (nRF24L01(+) supports 3,4 or 5 bytes).
