### PR TITLE
enable SoftSPI for RF24 when using ethernet cards

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -8,6 +8,11 @@
 
 #include "nRF24L01.h"
 #include "RF24_config.h"
+#ifdef SOFTSPI
+#include "DigitalIO.h"
+#else
+#include <SPI.h>
+#endif
 #include "RF24.h"
 
 /****************************************************************************/
@@ -19,9 +24,15 @@ void RF24::csn(int mode)
   // divider of 4 is the minimum we want.
   // CLK:BUS 8Mhz:2Mhz, 16Mhz:4Mhz, or 20Mhz:5Mhz
 #ifdef ARDUINO
+  //
+  //  we do not use these with SoftSPI
+  //
+#ifndef SOFTSPI
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
   SPI.setClockDivider(SPI_CLOCK_DIV4);
+#endif
+
 #endif
   digitalWrite(csn_pin,mode);
 }

--- a/RF24.h
+++ b/RF24.h
@@ -12,10 +12,15 @@
  * Class declaration for RF24 and helper enums
  */
 
+
 #ifndef __RF24_H__
 #define __RF24_H__
 
 #include <RF24_config.h>
+
+#ifdef SOFTSPI
+#include <DigitalIO.h>
+#endif
 
 /**
  * Power Amplifier level.
@@ -45,15 +50,18 @@ typedef enum { RF24_CRC_DISABLED = 0, RF24_CRC_8, RF24_CRC_16 } rf24_crclength_e
 class RF24
 {
 private:
-  uint8_t ce_pin; /**< "Chip Enable" pin, activates the RX or TX role */
-  uint8_t csn_pin; /**< SPI Chip select */
-  bool wide_band; /* 2Mbs data rate in use? */
-  bool p_variant; /* False for RF24L01 and true for RF24L01P */
-  uint8_t payload_size; /**< Fixed size of payloads */
-  bool ack_payload_available; /**< Whether there is an ack payload waiting */
-  bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */ 
-  uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */
-  uint64_t pipe0_reading_address; /**< Last address set on pipe 0 for reading. */
+#ifdef SOFTSPI
+	SoftSPI<SOFT_SPI_MISO_PIN, SOFT_SPI_MOSI_PIN, SOFT_SPI_SCK_PIN, SPI_MODE> spi;
+#endif
+	uint8_t ce_pin; /**< "Chip Enable" pin, activates the RX or TX role */
+	uint8_t csn_pin; /**< SPI Chip select */
+	bool wide_band; /* 2Mbs data rate in use? */
+	bool p_variant; /* False for RF24L01 and true for RF24L01P */
+	uint8_t payload_size; /**< Fixed size of payloads */
+	bool ack_payload_available; /**< Whether there is an ack payload waiting */
+	bool dynamic_payloads_enabled; /**< Whether dynamic payloads are enabled. */
+	uint8_t ack_payload_length; /**< Dynamic size of pending ack payload. */
+	uint64_t pipe0_reading_address; /**< Last address set on pipe 0 for reading. */
 
 protected:
   /**

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -35,6 +35,22 @@ extern HardwareSPI SPI;
 #else
 #define IF_SERIAL_DEBUG(x)
 #endif
+//
+// if we are using Soft SPI
+//
+#ifdef ARDUINO
+#define SOFTSPI				// comment out this line to use hardwarer SPI
+#ifdef SOFTSPI
+//
+// change these pins to your liking
+//
+const uint8_t SOFT_SPI_MISO_PIN = 16;
+const uint8_t SOFT_SPI_MOSI_PIN = 15;
+const uint8_t SOFT_SPI_SCK_PIN  = 14;
+const uint8_t SPI_MODE 			= 0;
+#define SPI spi
+#endif
+#endif
 
 // Avoid spurious warnings
 #if 1


### PR DESCRIPTION
These changes enable the RF24 library to choose to use either the hardware SPI of the SoftSPI from DigitalIO libary. It seems that both the W5100 and ECN28J60 ethernet shields are giving a lot of problems when using both the ethernet and the RF24 libs at the same time. By selecting SoftSPI for the RF24 this problem is eliminated.

In RF24_config.h the user can either comment out:
"#define SOFTSPI" in which case the hardware SPI will be used otherwise SoftSPI will be selected.

In the same file the user can select the pins to use for Clock, MOSI and MISO. Default they are now 14-15-16.
