### PR TITLE
Arduino Mega error fix

### DIFF
--- a/tests/pingpair_test/pingpair_test.pde
+++ b/tests/pingpair_test/pingpair_test.pde
@@ -216,7 +216,7 @@ void setup(void)
   }
   else if ( role == role_sender )
   {
-    radio.openReadingPipe(5,0);
+    radio.openReadingPipe((uint8_t)5,(uint64_t)0);
   }
 
   //


### PR DESCRIPTION
pingpair_test:214:35: error: call of overloaded 'openReadingPipe(int, int)' is ambiguous
         radio.openReadingPipe(5, 0);
                                   ^
fix the given error